### PR TITLE
Align frontend API defaults with backend base URL

### DIFF
--- a/store-frontend/app/articles/page.tsx
+++ b/store-frontend/app/articles/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useAuth } from '@/lib/AuthContext';
+import { API_URL } from '@/lib/api';
 
 interface Product {
   id: number;
@@ -39,8 +40,7 @@ export default function BoutiquePage() {
       setLoading(true);
       setError(null);
       
-      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api';
-      const response = await fetch(`${apiUrl}/products`);
+      const response = await fetch(`${API_URL}/products`);
       
       if (!response.ok) {
         throw new Error(`Failed to fetch products: ${response.status}`);

--- a/store-frontend/lib/api.ts
+++ b/store-frontend/lib/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 // Use environment variable for API URL, with fallback for development
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
+export const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api';
 
 const api = axios.create({
   baseURL: API_URL,


### PR DESCRIPTION
## Summary
- update the shared API helper to fall back to the backend's localhost port 5000
- export the API base URL constant and reuse it in the articles page fetch logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e10679ede8832890b528efa1cc64a8