### PR TITLE
Fix articles page build error by marking as client component

### DIFF
--- a/store-frontend/app/articles/page.tsx
+++ b/store-frontend/app/articles/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { BoutiqueCatalogue } from '@/components/BoutiqueCatalogue';
-
 import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';

--- a/store-frontend/app/articles/page.tsx
+++ b/store-frontend/app/articles/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { BoutiqueCatalogue } from '@/components/BoutiqueCatalogue';
 
 import { useState, useEffect } from 'react';

--- a/store-frontend/app/mentions-legales/page.tsx
+++ b/store-frontend/app/mentions-legales/page.tsx
@@ -21,8 +21,8 @@ export default function MentionsLegalesPage() {
         <section>
           <h2 className="text-2xl font-semibold mb-3">Hébergement</h2>
           <p>
-            Nom de l'hébergeur<br />
-            Adresse de l'hébergeur<br />
+            Nom de l&apos;hébergeur<br />
+            Adresse de l&apos;hébergeur<br />
             Téléphone : +33 1 98 76 54 32
           </p>
         </section>
@@ -30,7 +30,7 @@ export default function MentionsLegalesPage() {
         <section>
           <h2 className="text-2xl font-semibold mb-3">Propriété intellectuelle</h2>
           <p>
-            L'ensemble des contenus présents sur ce site (textes, images, logos, etc.) sont la
+            L&apos;ensemble des contenus présents sur ce site (textes, images, logos, etc.) sont la
             propriété de Belhos Accessories ou de ses partenaires. Toute reproduction, représentation,
             modification ou adaptation, totale ou partielle, est strictement interdite sans
             autorisation préalable.
@@ -42,7 +42,7 @@ export default function MentionsLegalesPage() {
           <p>
             Les informations communiquées sur ce site sont fournies à titre indicatif et peuvent être
             modifiées à tout moment. Belhos Accessories ne saurait être tenue responsable des dommages
-            directs ou indirects résultant de l'utilisation du site ou des informations qu'il contient.
+            directs ou indirects résultant de l&apos;utilisation du site ou des informations qu&apos;il contient.
           </p>
         </section>
       </div>

--- a/store-frontend/app/politique-de-confidentialite/page.tsx
+++ b/store-frontend/app/politique-de-confidentialite/page.tsx
@@ -16,7 +16,7 @@ export default function PolitiqueConfidentialitePage() {
           <h2 className="text-2xl font-semibold mb-3">Données collectées</h2>
           <p>
             Nous pouvons collecter des informations telles que votre nom, votre adresse email, votre
-            adresse postale et votre historique d'achats afin d'améliorer votre expérience client. Des
+            adresse postale et votre historique d&apos;achats afin d&apos;améliorer votre expérience client. Des
             données supplémentaires pourront être précisées ultérieurement.
           </p>
         </section>
@@ -26,24 +26,24 @@ export default function PolitiqueConfidentialitePage() {
           <p>
             Les informations recueillies sont utilisées pour traiter vos commandes, personnaliser vos
             interactions avec notre boutique et vous envoyer des communications pertinentes. Nous
-            n'utiliserons jamais vos données à d'autres fins sans votre consentement explicite.
+            n&apos;utiliserons jamais vos données à d&apos;autres fins sans votre consentement explicite.
           </p>
         </section>
 
         <section>
           <h2 className="text-2xl font-semibold mb-3">Partage des données</h2>
           <p>
-            Vos informations personnelles ne sont partagées qu'avec des partenaires de confiance qui
+            Vos informations personnelles ne sont partagées qu&apos;avec des partenaires de confiance qui
             respectent nos standards de sécurité et uniquement lorsque cela est nécessaire à la
-            fourniture du service. Aucun partage commercial n'est effectué sans votre accord.
+            fourniture du service. Aucun partage commercial n&apos;est effectué sans votre accord.
           </p>
         </section>
 
         <section>
           <h2 className="text-2xl font-semibold mb-3">Vos droits</h2>
           <p>
-            Vous disposez d'un droit d'accès, de rectification et de suppression de vos données
-            personnelles. Pour exercer ces droits, contactez-nous à l'adresse suivante :
+            Vous disposez d&apos;un droit d&apos;accès, de rectification et de suppression de vos données
+            personnelles. Pour exercer ces droits, contactez-nous à l&apos;adresse suivante :
             privacy@belhos-accessories.com.
           </p>
         </section>


### PR DESCRIPTION
## Summary
- mark the articles page as a client component so it can safely use React hooks

## Testing
- npm run build *(fails: next/font unable to fetch Geist fonts from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e1095ab88c8328b833bad485e5f1fb