### PR TITLE
Create StorefrontLayout and unify navigation across pages

### DIFF
--- a/store-frontend/app/articles/page.tsx
+++ b/store-frontend/app/articles/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useAuth } from '@/lib/AuthContext';
 import { API_URL } from '@/lib/api';
+import { StorefrontLayout } from '@/components/StorefrontLayout';
 
 interface Product {
   id: number;
@@ -15,13 +16,6 @@ interface Product {
   category: string;
   stock: number;
 }
-
-const navLinks = [
-  { href: '/', label: 'Accueil' },
-  { href: '/articles', label: 'Boutique' },
-  { href: '/reservations', label: 'Réservations' },
-  { href: '/contact', label: 'Contact' },
-];
 
 export default function BoutiquePage() {
   const [products, setProducts] = useState<Product[]>([]);
@@ -71,60 +65,22 @@ export default function BoutiquePage() {
   // Loading State
   if (loading) {
     return (
-      <div className="min-h-screen bg-white text-black">
-        <header className="sticky top-0 z-50 border-b border-black/10 bg-white/90 backdrop-blur">
-          <nav className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 text-[0.7rem] uppercase tracking-[0.35em] sm:px-6 md:flex-row md:items-center md:justify-between">
-            <Link href="/" className="text-sm font-semibold tracking-[0.45em]">
-              Belhos Accessories
-            </Link>
-            <div className="flex flex-wrap justify-center gap-6 text-[0.65rem] font-medium md:text-xs">
-              {navLinks.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="transition hover:text-black/60"
-                >
-                  {link.label}
-                </Link>
-              ))}
-            </div>
-          </nav>
-        </header>
-        <div className="mx-auto max-w-6xl px-4 py-24 sm:px-6">
-          <div className="flex flex-col items-center justify-center space-y-6">
-            <div className="h-12 w-12 animate-spin rounded-full border-2 border-black/20 border-t-black"></div>
-            <p className="text-sm uppercase tracking-[0.35em] text-black/60">Chargement de la boutique...</p>
-          </div>
+      <StorefrontLayout activePath="/articles">
+        <div className="flex flex-col items-center justify-center space-y-6 py-24">
+          <div className="h-12 w-12 animate-spin rounded-full border-2 border-black/20 border-t-black"></div>
+          <p className="text-sm uppercase tracking-[0.35em] text-black/60">Chargement de la boutique...</p>
         </div>
-      </div>
+      </StorefrontLayout>
     );
   }
 
   // Error State
   if (error) {
     return (
-      <div className="min-h-screen bg-white text-black">
-        <header className="sticky top-0 z-50 border-b border-black/10 bg-white/90 backdrop-blur">
-          <nav className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 text-[0.7rem] uppercase tracking-[0.35em] sm:px-6 md:flex-row md:items-center md:justify-between">
-            <Link href="/" className="text-sm font-semibold tracking-[0.45em]">
-              Belhos Accessories
-            </Link>
-            <div className="flex flex-wrap justify-center gap-6 text-[0.65rem] font-medium md:text-xs">
-              {navLinks.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="transition hover:text-black/60"
-                >
-                  {link.label}
-                </Link>
-              ))}
-            </div>
-          </nav>
-        </header>
-        <div className="mx-auto max-w-2xl px-4 py-24 sm:px-6">
+      <StorefrontLayout activePath="/articles">
+        <div className="mx-auto w-full max-w-2xl py-24">
           <div className="rounded-3xl border border-black/10 bg-white p-12 text-center shadow-sm">
-            <div className="text-4xl mb-6">⚠️</div>
+            <div className="mb-6 text-4xl">⚠️</div>
             <h2 className="mb-3 text-xl font-semibold tracking-[0.2em]">Une erreur est survenue</h2>
             <p className="mb-8 text-sm text-black/60">{error}</p>
             <button
@@ -135,50 +91,13 @@ export default function BoutiquePage() {
             </button>
           </div>
         </div>
-      </div>
+      </StorefrontLayout>
     );
   }
 
   return (
-    <div className="min-h-screen bg-white text-black">
-      {/* Header */}
-      <header className="sticky top-0 z-50 border-b border-black/10 bg-white/90 backdrop-blur">
-        <nav className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 text-[0.7rem] uppercase tracking-[0.35em] sm:px-6 md:flex-row md:items-center md:justify-between">
-          <Link href="/" className="text-sm font-semibold tracking-[0.45em]">
-            Belhos Accessories
-          </Link>
-          <div className="flex flex-wrap justify-center gap-6 text-[0.65rem] font-medium md:text-xs">
-            {navLinks.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                className={`transition ${
-                  link.href === '/articles' ? 'text-black' : 'hover:text-black/60'
-                }`}
-              >
-                {link.label}
-              </Link>
-            ))}
-          </div>
-          {user ? (
-            <Link
-              href="/reservations"
-              className="inline-flex items-center justify-center rounded-full border border-black px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] transition hover:bg-black hover:text-white"
-            >
-              Mes réservations
-            </Link>
-          ) : (
-            <Link
-              href="/login"
-              className="inline-flex items-center justify-center rounded-full border border-black px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] transition hover:bg-black hover:text-white"
-            >
-              Se connecter
-            </Link>
-          )}
-        </nav>
-      </header>
-
-      <main className="mx-auto max-w-6xl px-4 pb-24 pt-16 sm:px-6 lg:px-8">
+    <StorefrontLayout activePath="/articles">
+      <main>
         {/* Hero Section */}
         <section className="mb-16 space-y-8 text-center">
           <span className="inline-flex items-center rounded-full bg-black px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white">
@@ -360,6 +279,6 @@ export default function BoutiquePage() {
           </section>
         )}
       </main>
-    </div>
+    </StorefrontLayout>
   );
 }

--- a/store-frontend/app/contact/page.tsx
+++ b/store-frontend/app/contact/page.tsx
@@ -2,14 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-
-const navLinks = [
-  { href: '/', label: 'Accueil' },
-  { href: '/boutique', label: 'Boutique' },
-  { href: '/collections', label: 'Collections' },
-  { href: '/reservations', label: 'Réservations' },
-  { href: '/contact', label: 'Contact' },
-];
+import { StorefrontLayout } from '@/components/StorefrontLayout';
 
 export default function ContactPage() {
   const [formData, setFormData] = useState({
@@ -39,36 +32,8 @@ export default function ContactPage() {
   };
 
   return (
-    <div className="min-h-screen bg-white text-black">
-      {/* Header */}
-      <header className="sticky top-0 z-50 border-b border-black/10 bg-white/90 backdrop-blur">
-        <nav className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 text-[0.7rem] uppercase tracking-[0.35em] sm:px-6 md:flex-row md:items-center md:justify-between">
-          <Link href="/" className="text-sm font-semibold tracking-[0.45em]">
-            Belhos Accessories
-          </Link>
-          <div className="flex flex-wrap justify-center gap-6 text-[0.65rem] font-medium md:text-xs">
-            {navLinks.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                className={`transition ${
-                  link.href === '/contact' ? 'text-black' : 'hover:text-black/60'
-                }`}
-              >
-                {link.label}
-              </Link>
-            ))}
-          </div>
-          <Link
-            href="/reservations"
-            className="inline-flex items-center justify-center rounded-full border border-black px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] transition hover:bg-black hover:text-white"
-          >
-            Mes réservations
-          </Link>
-        </nav>
-      </header>
-
-      <main className="mx-auto max-w-6xl px-4 pb-24 pt-16 sm:px-6 lg:px-8">
+    <StorefrontLayout activePath="/contact">
+      <main>
         {/* Hero Section */}
         <section className="mb-16 space-y-8 text-center">
           <span className="inline-flex items-center rounded-full bg-black px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white">
@@ -280,6 +245,6 @@ export default function ContactPage() {
           </div>
         </section>
       </main>
-    </div>
+    </StorefrontLayout>
   );
 }

--- a/store-frontend/app/reservations/page.tsx
+++ b/store-frontend/app/reservations/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useAuth } from '@/lib/AuthContext';
 import { useRouter, useSearchParams } from 'next/navigation';
 import api from '@/lib/api';
+import { StorefrontLayout } from '@/components/StorefrontLayout';
 
 interface Product {
   id: number;
@@ -22,14 +23,6 @@ interface Reservation {
   createdAt: string;
   product: Product;
 }
-
-const navLinks = [
-  { href: '/', label: 'Accueil' },
-  { href: '/boutique', label: 'Boutique' },
-  { href: '/collections', label: 'Collections' },
-  { href: '/reservations', label: 'Réservations' },
-  { href: '/contact', label: 'Contact' },
-];
 
 const statusLabels: Record<string, string> = {
   pending: 'En attente',
@@ -129,66 +122,18 @@ function ReservationsContent() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-white text-black">
-        <header className="sticky top-0 z-50 border-b border-black/10 bg-white/90 backdrop-blur">
-          <nav className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 text-[0.7rem] uppercase tracking-[0.35em] sm:px-6 md:flex-row md:items-center md:justify-between">
-            <Link href="/" className="text-sm font-semibold tracking-[0.45em]">
-              Belhos Accessories
-            </Link>
-            <div className="flex flex-wrap justify-center gap-6 text-[0.65rem] font-medium md:text-xs">
-              {navLinks.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="transition hover:text-black/60"
-                >
-                  {link.label}
-                </Link>
-              ))}
-            </div>
-          </nav>
-        </header>
-        <div className="mx-auto max-w-6xl px-4 py-24 sm:px-6">
-          <div className="flex flex-col items-center justify-center space-y-6">
-            <div className="h-12 w-12 animate-spin rounded-full border-2 border-black/20 border-t-black"></div>
-            <p className="text-sm uppercase tracking-[0.35em] text-black/60">Chargement...</p>
-          </div>
+      <StorefrontLayout activePath="/reservations">
+        <div className="flex flex-col items-center justify-center space-y-6 py-24">
+          <div className="h-12 w-12 animate-spin rounded-full border-2 border-black/20 border-t-black"></div>
+          <p className="text-sm uppercase tracking-[0.35em] text-black/60">Chargement...</p>
         </div>
-      </div>
+      </StorefrontLayout>
     );
   }
 
   return (
-    <div className="min-h-screen bg-white text-black">
-      {/* Header */}
-      <header className="sticky top-0 z-50 border-b border-black/10 bg-white/90 backdrop-blur">
-        <nav className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 text-[0.7rem] uppercase tracking-[0.35em] sm:px-6 md:flex-row md:items-center md:justify-between">
-          <Link href="/" className="text-sm font-semibold tracking-[0.45em]">
-            Belhos Accessories
-          </Link>
-          <div className="flex flex-wrap justify-center gap-6 text-[0.65rem] font-medium md:text-xs">
-            {navLinks.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                className={`transition ${
-                  link.href === '/reservations' ? 'text-black' : 'hover:text-black/60'
-                }`}
-              >
-                {link.label}
-              </Link>
-            ))}
-          </div>
-          <Link
-            href="/boutique"
-            className="inline-flex items-center justify-center rounded-full border border-black px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] transition hover:bg-black hover:text-white"
-          >
-            Retour à la boutique
-          </Link>
-        </nav>
-      </header>
-
-      <main className="mx-auto max-w-6xl px-4 pb-24 pt-16 sm:px-6 lg:px-8">
+    <StorefrontLayout activePath="/reservations">
+      <main>
         {/* Hero Section */}
         <section className="mb-16 space-y-8 text-center">
           <span className="inline-flex items-center rounded-full bg-black px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white">
@@ -420,40 +365,22 @@ function ReservationsContent() {
           </Link>
         </section>
       </main>
-    </div>
+    </StorefrontLayout>
   );
 }
 
 export default function ReservationsPage() {
   return (
-    <Suspense fallback={
-      <div className="min-h-screen bg-white text-black">
-        <header className="sticky top-0 z-50 border-b border-black/10 bg-white/90 backdrop-blur">
-          <nav className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 text-[0.7rem] uppercase tracking-[0.35em] sm:px-6 md:flex-row md:items-center md:justify-between">
-            <Link href="/" className="text-sm font-semibold tracking-[0.45em]">
-              Belhos Accessories
-            </Link>
-            <div className="flex flex-wrap justify-center gap-6 text-[0.65rem] font-medium md:text-xs">
-              {navLinks.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="transition hover:text-black/60"
-                >
-                  {link.label}
-                </Link>
-              ))}
-            </div>
-          </nav>
-        </header>
-        <div className="mx-auto max-w-6xl px-4 py-24 sm:px-6">
-          <div className="flex flex-col items-center justify-center space-y-6">
+    <Suspense
+      fallback={
+        <StorefrontLayout activePath="/reservations">
+          <div className="flex flex-col items-center justify-center space-y-6 py-24">
             <div className="h-12 w-12 animate-spin rounded-full border-2 border-black/20 border-t-black"></div>
             <p className="text-sm uppercase tracking-[0.35em] text-black/60">Chargement...</p>
           </div>
-        </div>
-      </div>
-    }>
+        </StorefrontLayout>
+      }
+    >
       <ReservationsContent />
     </Suspense>
   );

--- a/store-frontend/components/BoutiqueCatalogue.tsx
+++ b/store-frontend/components/BoutiqueCatalogue.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
 import { useAuth } from '@/lib/AuthContext';
+import Link from 'next/link';
+import { StorefrontLayout } from './StorefrontLayout';
 
 interface Product {
   id: number;
@@ -15,18 +16,7 @@ interface Product {
   stock: number;
 }
 
-const navLinks = [
-  { href: '/', label: 'Accueil' },
-  { href: '/boutique', label: 'Boutique' },
-  { href: '/reservations', label: 'Réservations' },
-  { href: '/contact', label: 'Contact' },
-];
-
-interface BoutiqueCatalogueProps {
-  activePath?: string;
-}
-
-export function BoutiqueCatalogue({ activePath = '/boutique' }: BoutiqueCatalogueProps) {
+export function BoutiqueCatalogue() {
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -72,63 +62,23 @@ export function BoutiqueCatalogue({ activePath = '/boutique' }: BoutiqueCatalogu
     return matchesSearch && matchesCategory;
   });
 
-  const Nav = (
-    <header className="sticky top-0 z-50 border-b border-black/10 bg-white/90 backdrop-blur">
-      <nav className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-6 text-[0.7rem] uppercase tracking-[0.35em] sm:px-6 md:flex-row md:items-center md:justify-between">
-        <Link href="/" className="text-sm font-semibold tracking-[0.45em]">
-          Belhos Accessories
-        </Link>
-        <div className="flex flex-wrap justify-center gap-6 text-[0.65rem] font-medium md:text-xs">
-          {navLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className={`transition ${link.href === activePath ? 'text-black' : 'hover:text-black/60'}`}
-            >
-              {link.label}
-            </Link>
-          ))}
-        </div>
-        {user ? (
-          <Link
-            href="/reservations"
-            className="inline-flex items-center justify-center rounded-full border border-black px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] transition hover:bg-black hover:text-white"
-          >
-            Mes réservations
-          </Link>
-        ) : (
-          <Link
-            href="/login"
-            className="inline-flex items-center justify-center rounded-full border border-black px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] transition hover:bg-black hover:text-white"
-          >
-            Se connecter
-          </Link>
-        )}
-      </nav>
-    </header>
-  );
-
   if (loading) {
     return (
-      <div className="min-h-screen bg-white text-black">
-        {Nav}
-        <div className="mx-auto max-w-6xl px-4 py-24 sm:px-6">
-          <div className="flex flex-col items-center justify-center space-y-6">
-            <div className="h-12 w-12 animate-spin rounded-full border-2 border-black/20 border-t-black"></div>
-            <p className="text-sm uppercase tracking-[0.35em] text-black/60">Chargement de la boutique...</p>
-          </div>
+      <StorefrontLayout activePath="/boutique">
+        <div className="flex flex-col items-center justify-center space-y-6 py-24">
+          <div className="h-12 w-12 animate-spin rounded-full border-2 border-black/20 border-t-black"></div>
+          <p className="text-sm uppercase tracking-[0.35em] text-black/60">Chargement de la boutique...</p>
         </div>
-      </div>
+      </StorefrontLayout>
     );
   }
 
   if (error) {
     return (
-      <div className="min-h-screen bg-white text-black">
-        {Nav}
-        <div className="mx-auto max-w-2xl px-4 py-24 sm:px-6">
+      <StorefrontLayout activePath="/boutique">
+        <div className="mx-auto w-full max-w-2xl py-24">
           <div className="rounded-3xl border border-black/10 bg-white p-12 text-center shadow-sm">
-            <div className="text-4xl mb-6">⚠️</div>
+            <div className="mb-6 text-4xl">⚠️</div>
             <h2 className="mb-3 text-xl font-semibold tracking-[0.2em]">Une erreur est survenue</h2>
             <p className="mb-8 text-sm text-black/60">{error}</p>
             <button
@@ -139,15 +89,13 @@ export function BoutiqueCatalogue({ activePath = '/boutique' }: BoutiqueCatalogu
             </button>
           </div>
         </div>
-      </div>
+      </StorefrontLayout>
     );
   }
 
   return (
-    <div className="min-h-screen bg-white text-black">
-      {Nav}
-
-      <main className="mx-auto max-w-6xl px-4 pb-24 pt-16 sm:px-6 lg:px-8">
+    <StorefrontLayout activePath="/boutique">
+      <main>
         <section className="mb-16 space-y-8 text-center">
           <span className="inline-flex items-center rounded-full bg-black px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white">
             Boutique Exclusive
@@ -292,6 +240,6 @@ export function BoutiqueCatalogue({ activePath = '/boutique' }: BoutiqueCatalogu
           </section>
         )}
       </main>
-    </div>
+    </StorefrontLayout>
   );
 }

--- a/store-frontend/components/HomeHeader.tsx
+++ b/store-frontend/components/HomeHeader.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
+import { usePathname } from 'next/navigation';
 
 export type HomeNavLink = {
   href: string;
@@ -10,10 +11,13 @@ export type HomeNavLink = {
 
 interface HomeHeaderProps {
   links: HomeNavLink[];
+  activePath?: string;
 }
 
-export function HomeHeader({ links }: HomeHeaderProps) {
+export function HomeHeader({ links, activePath }: HomeHeaderProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const pathname = usePathname();
+  const currentPath = useMemo(() => activePath ?? pathname ?? '/', [activePath, pathname]);
 
   return (
     <header className="sticky top-0 z-50 border-b border-black/10 bg-white/95 backdrop-blur">
@@ -36,15 +40,19 @@ export function HomeHeader({ links }: HomeHeaderProps) {
         </button>
 
         <nav className="hidden items-center gap-8 text-[0.7rem] uppercase tracking-[0.35em] text-black/80 lg:flex">
-          {links.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="transition hover:text-black"
-            >
-              {link.label}
-            </Link>
-          ))}
+          {links.map((link) => {
+            const isActive = currentPath === link.href;
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                aria-current={isActive ? 'page' : undefined}
+                className={`transition ${isActive ? 'text-black' : 'hover:text-black'}`}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
         </nav>
 
         <Link
@@ -58,16 +66,20 @@ export function HomeHeader({ links }: HomeHeaderProps) {
       {isMenuOpen && (
         <nav className="border-t border-black/10 bg-white lg:hidden">
           <div className="mx-auto flex max-w-6xl flex-col gap-3 px-4 py-4 text-xs uppercase tracking-[0.3em] text-black/80 sm:px-6">
-            {links.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                className="py-1 transition hover:text-black"
-                onClick={() => setIsMenuOpen(false)}
-              >
-                {link.label}
-              </Link>
-            ))}
+            {links.map((link) => {
+              const isActive = currentPath === link.href;
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  aria-current={isActive ? 'page' : undefined}
+                  className={`py-1 transition ${isActive ? 'text-black' : 'hover:text-black'}`}
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
             <Link
               href="/reservations"
               className="mt-2 inline-flex items-center justify-center rounded-full border border-black px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-black transition hover:bg-black hover:text-white"

--- a/store-frontend/components/StorefrontLayout.tsx
+++ b/store-frontend/components/StorefrontLayout.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { ReactNode, useMemo } from 'react';
+import { usePathname } from 'next/navigation';
+import { HomeHeader, HomeNavLink } from './HomeHeader';
+import { SiteFooter } from './SiteFooter';
+
+export const STORE_NAV_LINKS: HomeNavLink[] = [
+  { href: '/', label: 'Accueil' },
+  { href: '/boutique', label: 'Boutique' },
+  { href: '/articles', label: 'Articles' },
+  { href: '/reservations', label: 'Réservations' },
+  { href: '/contact', label: 'Contact' },
+];
+
+interface StorefrontLayoutProps {
+  children: ReactNode;
+  activePath?: string;
+}
+
+export function StorefrontLayout({ children, activePath }: StorefrontLayoutProps) {
+  const pathname = usePathname();
+  const currentPath = useMemo(() => activePath ?? pathname ?? '/', [activePath, pathname]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white text-black">
+      <HomeHeader links={STORE_NAV_LINKS} activePath={currentPath} />
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 pb-24 pt-16 sm:px-6 lg:px-8">{children}</main>
+      <SiteFooter />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client StorefrontLayout component that composes the shared header, footer, and navigation links
- enhance HomeHeader with active link highlighting driven by the current path
- refactor boutique, articles, contact, and reservations views to reuse the storefront layout including suspense fallbacks

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e151641b2c8328a0aa65b6f9a5bb15