### PR TITLE
Apply Storefront layout to legal pages

### DIFF
--- a/store-frontend/app/mentions-legales/page.tsx
+++ b/store-frontend/app/mentions-legales/page.tsx
@@ -1,51 +1,62 @@
+import StorefrontLayout from '@/components/StorefrontLayout';
+
 export default function MentionsLegalesPage() {
   return (
-    <div className="container mx-auto px-4 py-16">
-      <h1 className="text-4xl font-bold mb-8 text-center">Mentions légales</h1>
-      <div className="space-y-6 text-gray-700 leading-relaxed">
-        <section>
-          <h2 className="text-2xl font-semibold mb-3">Éditeur du site</h2>
-          <p>
-            Belhos Accessories<br />
-            123 Rue de la Mode, 75000 Paris<br />
-            contact@belhos-accessories.com<br />
-            +33 1 23 45 67 89
-          </p>
-        </section>
+    <StorefrontLayout activePath="/mentions-legales">
+      <div className="mx-auto w-full max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+        <h1 className="mb-10 text-center text-3xl font-semibold tracking-[0.2em] sm:text-4xl">
+          Mentions légales
+        </h1>
+        <div className="space-y-8 text-sm leading-relaxed text-black/70 sm:text-base">
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-[0.15em] text-black sm:text-2xl">Éditeur du site</h2>
+            <p>
+              Belhos Accessories
+              <br />
+              123 Rue de la Mode, 75000 Paris
+              <br />
+              contact@belhos-accessories.com
+              <br />
+              +33 1 23 45 67 89
+            </p>
+          </section>
 
-        <section>
-          <h2 className="text-2xl font-semibold mb-3">Directeur de publication</h2>
-          <p>Nom du responsable – Directeur général.</p>
-        </section>
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-[0.15em] text-black sm:text-2xl">Directeur de publication</h2>
+            <p>Nom du responsable – Directeur général.</p>
+          </section>
 
-        <section>
-          <h2 className="text-2xl font-semibold mb-3">Hébergement</h2>
-          <p>
-            Nom de l&apos;hébergeur<br />
-            Adresse de l&apos;hébergeur<br />
-            Téléphone : +33 1 98 76 54 32
-          </p>
-        </section>
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-[0.15em] text-black sm:text-2xl">Hébergement</h2>
+            <p>
+              Nom de l&apos;hébergeur
+              <br />
+              Adresse de l&apos;hébergeur
+              <br />
+              Téléphone : +33 1 98 76 54 32
+            </p>
+          </section>
 
-        <section>
-          <h2 className="text-2xl font-semibold mb-3">Propriété intellectuelle</h2>
-          <p>
-            L&apos;ensemble des contenus présents sur ce site (textes, images, logos, etc.) sont la
-            propriété de Belhos Accessories ou de ses partenaires. Toute reproduction, représentation,
-            modification ou adaptation, totale ou partielle, est strictement interdite sans
-            autorisation préalable.
-          </p>
-        </section>
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-[0.15em] text-black sm:text-2xl">Propriété intellectuelle</h2>
+            <p>
+              L&apos;ensemble des contenus présents sur ce site (textes, images, logos, etc.) sont la
+              propriété de Belhos Accessories ou de ses partenaires. Toute reproduction, représentation,
+              modification ou adaptation, totale ou partielle, est strictement interdite sans
+              autorisation préalable.
+            </p>
+          </section>
 
-        <section>
-          <h2 className="text-2xl font-semibold mb-3">Responsabilité</h2>
-          <p>
-            Les informations communiquées sur ce site sont fournies à titre indicatif et peuvent être
-            modifiées à tout moment. Belhos Accessories ne saurait être tenue responsable des dommages
-            directs ou indirects résultant de l&apos;utilisation du site ou des informations qu&apos;il contient.
-          </p>
-        </section>
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-[0.15em] text-black sm:text-2xl">Responsabilité</h2>
+            <p>
+              Les informations communiquées sur ce site sont fournies à titre indicatif et peuvent être
+              modifiées à tout moment. Belhos Accessories ne saurait être tenue responsable des dommages
+              directs ou indirects résultant de l&apos;utilisation du site ou des informations qu&apos;il contient.
+            </p>
+          </section>
+        </div>
       </div>
-    </div>
+    </StorefrontLayout>
   );
 }

--- a/store-frontend/app/politique-de-confidentialite/page.tsx
+++ b/store-frontend/app/politique-de-confidentialite/page.tsx
@@ -1,53 +1,58 @@
+import StorefrontLayout from '@/components/StorefrontLayout';
+
 export default function PolitiqueConfidentialitePage() {
   return (
-    <div className="container mx-auto px-4 py-16">
-      <h1 className="text-4xl font-bold mb-8 text-center">Politique de confidentialité</h1>
-      <div className="space-y-6 text-gray-700 leading-relaxed">
-        <section>
-          <h2 className="text-2xl font-semibold mb-3">Introduction</h2>
-          <p>
-            Cette politique de confidentialité explique comment Belhos Accessories collecte, utilise et
-            protège vos données personnelles lorsque vous visitez notre site ou utilisez nos services.
-            Ce texte est fourni à titre indicatif et sera mis à jour avec les informations définitives.
-          </p>
-        </section>
+    <StorefrontLayout activePath="/politique-de-confidentialite">
+      <div className="mx-auto w-full max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+        <h1 className="mb-10 text-center text-3xl font-semibold tracking-[0.2em] sm:text-4xl">
+          Politique de confidentialité
+        </h1>
+        <div className="space-y-8 text-sm leading-relaxed text-black/70 sm:text-base">
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-[0.15em] text-black sm:text-2xl">Introduction</h2>
+            <p>
+              Cette politique de confidentialité explique comment Belhos Accessories collecte, utilise et protège vos données
+              personnelles lorsque vous visitez notre site ou utilisez nos services. Ce texte est fourni à titre indicatif et
+              sera mis à jour avec les informations définitives.
+            </p>
+          </section>
 
-        <section>
-          <h2 className="text-2xl font-semibold mb-3">Données collectées</h2>
-          <p>
-            Nous pouvons collecter des informations telles que votre nom, votre adresse email, votre
-            adresse postale et votre historique d&apos;achats afin d&apos;améliorer votre expérience client. Des
-            données supplémentaires pourront être précisées ultérieurement.
-          </p>
-        </section>
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-[0.15em] text-black sm:text-2xl">Données collectées</h2>
+            <p>
+              Nous pouvons collecter des informations telles que votre nom, votre adresse email, votre adresse postale et votre
+              historique d&apos;achats afin d&apos;améliorer votre expérience client. Des données supplémentaires pourront être précisées
+              ultérieurement.
+            </p>
+          </section>
 
-        <section>
-          <h2 className="text-2xl font-semibold mb-3">Utilisation des données</h2>
-          <p>
-            Les informations recueillies sont utilisées pour traiter vos commandes, personnaliser vos
-            interactions avec notre boutique et vous envoyer des communications pertinentes. Nous
-            n&apos;utiliserons jamais vos données à d&apos;autres fins sans votre consentement explicite.
-          </p>
-        </section>
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-[0.15em] text-black sm:text-2xl">Utilisation des données</h2>
+            <p>
+              Les informations recueillies sont utilisées pour traiter vos commandes, personnaliser vos interactions avec notre
+              boutique et vous envoyer des communications pertinentes. Nous n&apos;utiliserons jamais vos données à d&apos;autres fins sans
+              votre consentement explicite.
+            </p>
+          </section>
 
-        <section>
-          <h2 className="text-2xl font-semibold mb-3">Partage des données</h2>
-          <p>
-            Vos informations personnelles ne sont partagées qu&apos;avec des partenaires de confiance qui
-            respectent nos standards de sécurité et uniquement lorsque cela est nécessaire à la
-            fourniture du service. Aucun partage commercial n&apos;est effectué sans votre accord.
-          </p>
-        </section>
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-[0.15em] text-black sm:text-2xl">Partage des données</h2>
+            <p>
+              Vos informations personnelles ne sont partagées qu&apos;avec des partenaires de confiance qui respectent nos standards de
+              sécurité et uniquement lorsque cela est nécessaire à la fourniture du service. Aucun partage commercial n&apos;est
+              effectué sans votre accord.
+            </p>
+          </section>
 
-        <section>
-          <h2 className="text-2xl font-semibold mb-3">Vos droits</h2>
-          <p>
-            Vous disposez d&apos;un droit d&apos;accès, de rectification et de suppression de vos données
-            personnelles. Pour exercer ces droits, contactez-nous à l&apos;adresse suivante :
-            privacy@belhos-accessories.com.
-          </p>
-        </section>
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold tracking-[0.15em] text-black sm:text-2xl">Vos droits</h2>
+            <p>
+              Vous disposez d&apos;un droit d&apos;accès, de rectification et de suppression de vos données personnelles. Pour exercer ces
+              droits, contactez-nous à l&apos;adresse suivante : privacy@belhos-accessories.com.
+            </p>
+          </section>
+        </div>
       </div>
-    </div>
+    </StorefrontLayout>
   );
 }

--- a/store-frontend/components/StorefrontLayout.tsx
+++ b/store-frontend/components/StorefrontLayout.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import { SiteFooter } from '@/components/SiteFooter';
+
+const navLinks = [
+  { href: '/', label: 'Accueil' },
+  { href: '/boutique', label: 'Boutique' },
+  { href: '/collections', label: 'Collections' },
+  { href: '/reservations', label: 'Réservations' },
+  { href: '/contact', label: 'Contact' },
+  { href: '/mentions-legales', label: 'Mentions légales' },
+  { href: '/politique-de-confidentialite', label: 'Confidentialité' },
+];
+
+interface StorefrontLayoutProps {
+  children: ReactNode;
+  activePath?: string;
+}
+
+export function StorefrontLayout({ children, activePath }: StorefrontLayoutProps) {
+  return (
+    <div className="min-h-screen bg-white text-black">
+      <header className="sticky top-0 z-40 border-b border-black/10 bg-white/95 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-5 text-[0.65rem] uppercase tracking-[0.3em] text-black/70 sm:px-6 md:flex-row md:items-center md:justify-between">
+          <Link
+            href="/"
+            className="text-sm font-semibold uppercase tracking-[0.35em] text-black transition hover:text-black/70"
+          >
+            Belhos Accessories
+          </Link>
+
+          <nav className="flex flex-wrap justify-center gap-5 text-[0.6rem] uppercase tracking-[0.3em] md:text-[0.65rem]">
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`transition hover:text-black ${
+                  activePath === link.href ? 'text-black' : 'text-black/60'
+                }`}
+                aria-current={activePath === link.href ? 'page' : undefined}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+
+          <Link
+            href="/reservations"
+            className="inline-flex items-center justify-center rounded-full border border-black px-6 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-black transition hover:bg-black hover:text-white"
+          >
+            Sur rendez-vous
+          </Link>
+        </div>
+      </header>
+
+      <main className="flex-1">{children}</main>
+
+      <SiteFooter />
+    </div>
+  );
+}
+
+export default StorefrontLayout;


### PR DESCRIPTION
## Summary
- add a reusable StorefrontLayout with storefront navigation and footer styling
- wrap the legal content pages in the new layout and align spacing and typography with the landing design

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e1516741088328b6766878fc9c536e