### PR TITLE
Fix articles nav label

### DIFF
--- a/store-frontend/app/articles/page.tsx
+++ b/store-frontend/app/articles/page.tsx
@@ -18,7 +18,7 @@ interface Product {
 
 const navLinks = [
   { href: '/', label: 'Accueil' },
-  { href: '/articles', label: 'Boutique' },
+  { href: '/articles', label: 'Articles' },
   { href: '/reservations', label: 'Réservations' },
   { href: '/contact', label: 'Contact' },
 ];


### PR DESCRIPTION
## Summary
- update the Articles page navigation configuration so the `/articles` link renders the "Articles" label across its header menus

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e15167ff90832894fd2801c188de82