### PR TITLE
Fix Next.js output tracing configuration

### DIFF
--- a/store-frontend/next.config.ts
+++ b/store-frontend/next.config.ts
@@ -19,7 +19,6 @@ const nextConfig: NextConfig = {
   },
   // Optimize for Vercel deployment
   output: 'standalone',
-  outputFileTracingRoot: '/home/bross/BELHOS-ACCESSORIES',
   // Environment variables validation
   env: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,


### PR DESCRIPTION
## Summary
- remove the hardcoded `outputFileTracingRoot` value so builds no longer resolve to an invalid path on Vercel

## Testing
- npm run build *(fails in this environment while fetching Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68e15c5d41ec8328a4984768136ca477