### PR TITLE
Align shared navbar styling with refreshed storefront header

### DIFF
--- a/store-frontend/app/(with-navigation)/login/page.tsx
+++ b/store-frontend/app/(with-navigation)/login/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/lib/AuthContext';
@@ -25,58 +26,94 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="container mx-auto px-4 py-16 max-w-md">
-      <h1 className="text-4xl font-bold mb-8 text-center">Connexion</h1>
+    <div className="bg-neutral-50">
+      <div className="mx-auto grid max-w-5xl gap-12 px-4 py-20 sm:px-6 lg:grid-cols-[1.1fr_0.9fr] lg:px-8">
+        <div className="space-y-8 text-black">
+          <span className="inline-flex items-center rounded-full bg-black px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white">
+            Espace privé
+          </span>
+          <h1 className="text-3xl font-semibold tracking-[0.2em] sm:text-4xl">
+            Connectez-vous à votre univers Belhos
+          </h1>
+          <p className="max-w-xl text-sm leading-relaxed text-black/70 sm:text-base">
+            Accédez à vos réservations, suivez vos commandes et retrouvez vos sélections favorites. Votre espace personnel vous permet de garder un lien privilégié avec notre maison.
+          </p>
 
-      {error && (
-        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-          {error}
-        </div>
-      )}
-
-      <form onSubmit={handleSubmit} className="bg-white shadow-lg rounded-lg p-8">
-        <div className="mb-6">
-          <label htmlFor="email" className="block text-gray-700 font-bold mb-2">
-            Email
-          </label>
-          <input
-            type="email"
-            id="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-            required
-          />
-        </div>
-
-        <div className="mb-6">
-          <label htmlFor="password" className="block text-gray-700 font-bold mb-2">
-            Mot de passe
-          </label>
-          <input
-            type="password"
-            id="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-            required
-          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm">
+              <p className="text-[0.65rem] uppercase tracking-[0.3em] text-black/60">Programme clients</p>
+              <p className="mt-3 text-lg font-semibold">Invitations privées</p>
+              <p className="mt-2 text-xs text-black/60">Des rendez-vous exclusifs pour découvrir nos nouveautés.</p>
+            </div>
+            <div className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm">
+              <p className="text-[0.65rem] uppercase tracking-[0.3em] text-black/60">Suivi personnalisé</p>
+              <p className="mt-3 text-lg font-semibold">Commandes & réservations</p>
+              <p className="mt-2 text-xs text-black/60">Retrouvez l&apos;historique de vos pièces et vos demandes sur-mesure.</p>
+            </div>
+          </div>
         </div>
 
-        <button
-          type="submit"
-          className="w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded-lg transition"
-        >
-          Se connecter
-        </button>
+        <div className="rounded-[32px] border border-black/10 bg-white p-10 shadow-sm shadow-black/5">
+          <div className="space-y-6">
+            <div className="space-y-2 text-center">
+              <h2 className="text-2xl font-semibold tracking-[0.2em]">Connexion</h2>
+              <p className="text-sm text-black/60">Indiquez votre email et votre mot de passe pour accéder à votre espace.</p>
+            </div>
 
-        <p className="mt-4 text-center text-gray-600">
-          Pas encore de compte?{' '}
-          <a href="/register" className="text-blue-500 hover:underline">
-            S&apos;inscrire
-          </a>
-        </p>
-      </form>
+            {error && (
+              <div className="rounded-2xl border border-red-200 bg-red-50 px-5 py-4 text-sm text-red-600">
+                {error}
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="space-y-2">
+                <label htmlFor="email" className="block text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-black/70">
+                  Email
+                </label>
+                <input
+                  type="email"
+                  id="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full rounded-full border border-black/20 bg-white px-6 py-3 text-sm focus:border-black focus:outline-none"
+                  autoComplete="email"
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="password" className="block text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-black/70">
+                  Mot de passe
+                </label>
+                <input
+                  type="password"
+                  id="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="w-full rounded-full border border-black/20 bg-white px-6 py-3 text-sm focus:border-black focus:outline-none"
+                  autoComplete="current-password"
+                  required
+                />
+              </div>
+
+              <button
+                type="submit"
+                className="inline-flex w-full items-center justify-center rounded-full bg-black px-6 py-3 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-black/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
+              >
+                Se connecter
+              </button>
+            </form>
+
+            <p className="text-center text-xs uppercase tracking-[0.3em] text-black/60">
+              Pas encore de compte ?{' '}
+              <Link href="/register" className="text-black transition hover:text-black/70">
+                S&apos;inscrire
+              </Link>
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/store-frontend/components/Navbar.tsx
+++ b/store-frontend/components/Navbar.tsx
@@ -1,65 +1,182 @@
 'use client';
 
 import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import { useAuth } from '@/lib/AuthContext';
+
+const primaryLinks = [
+  { href: '/', label: 'Accueil' },
+  { href: '/boutique', label: 'Boutique' },
+  { href: '/collections', label: 'Collections' },
+  { href: '/contact', label: 'Contact' },
+];
 
 export function Navbar() {
   const { user, logout, isAdmin } = useAuth();
+  const pathname = usePathname();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const currentPath = useMemo(() => pathname ?? '/', [pathname]);
+
+  const handleToggle = () => {
+    setIsMenuOpen((open) => !open);
+  };
+
+  const handleCloseMenu = () => {
+    setIsMenuOpen(false);
+  };
 
   return (
-    <nav className="bg-gray-800 text-white shadow-lg">
-      <div className="container mx-auto px-4 py-4">
-        <div className="flex justify-between items-center">
-          <Link href="/" className="text-2xl font-bold">
-            BELHOS ACCESSORIES
+    <header className="sticky top-0 z-50 border-b border-black/10 bg-white/95 text-black backdrop-blur">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-8">
+        <Link
+          href="/"
+          className="text-sm font-semibold uppercase tracking-[0.3em] transition hover:text-black/70 sm:text-base"
+        >
+          Belhos Accessories
+        </Link>
+
+        <button
+          type="button"
+          aria-label="Basculer la navigation"
+          aria-expanded={isMenuOpen}
+          onClick={handleToggle}
+          className="inline-flex items-center justify-center rounded-full border border-black/20 px-4 py-2 text-[0.6rem] uppercase tracking-[0.35em] transition hover:border-black/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 lg:hidden"
+        >
+          {isMenuOpen ? 'Fermer' : 'Menu'}
+        </button>
+
+        <nav className="hidden items-center gap-8 text-[0.7rem] uppercase tracking-[0.35em] text-black/80 lg:flex">
+          {primaryLinks.map((link) => {
+            const isActive = currentPath === link.href;
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                aria-current={isActive ? 'page' : undefined}
+                className={`transition ${isActive ? 'text-black' : 'hover:text-black'}`}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <div className="hidden items-center gap-3 lg:flex">
+          <Link
+            href="/reservations"
+            className="inline-flex items-center justify-center rounded-full border border-black px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] transition hover:bg-black hover:text-white"
+          >
+            Sur rendez-vous
           </Link>
 
-          <div className="flex space-x-6 items-center">
-            <Link href="/" className="hover:text-gray-300">
-              Accueil
-            </Link>
-            <Link href="/boutique" className="hover:text-gray-300">
-              Boutique
-            </Link>
-            <Link href="/reservations" className="hover:text-gray-300">
-              Réservations
-            </Link>
-            <Link href="/contact" className="hover:text-gray-300">
-              Contact
-            </Link>
+          {user ? (
+            <div className="flex items-center gap-3 text-[0.6rem] uppercase tracking-[0.3em]">
+              {isAdmin && (
+                <Link
+                  href="/admin"
+                  className="inline-flex items-center justify-center rounded-full border border-black px-4 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.3em] transition hover:bg-black hover:text-white"
+                >
+                  Espace admin
+                </Link>
+              )}
+              <span className="text-black/60">Bonjour, {user.name}</span>
+              <button
+                type="button"
+                onClick={logout}
+                className="inline-flex items-center justify-center rounded-full bg-black px-5 py-2 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-black/80"
+              >
+                Déconnexion
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-3 text-[0.65rem] uppercase tracking-[0.3em]">
+              <Link href="/login" className="transition hover:text-black/60">
+                Connexion
+              </Link>
+              <Link
+                href="/register"
+                className="inline-flex items-center justify-center rounded-full bg-black px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-black/80"
+              >
+                S&apos;inscrire
+              </Link>
+            </div>
+          )}
+        </div>
+      </div>
 
+      {isMenuOpen && (
+        <div className="border-t border-black/10 bg-white/95 lg:hidden">
+          <nav className="mx-auto flex max-w-6xl flex-col gap-3 px-4 py-4 text-xs uppercase tracking-[0.3em] text-black/80 sm:px-6">
+            {primaryLinks.map((link) => {
+              const isActive = currentPath === link.href;
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  aria-current={isActive ? 'page' : undefined}
+                  className={`py-1 transition ${isActive ? 'text-black' : 'hover:text-black'}`}
+                  onClick={handleCloseMenu}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </nav>
+          <div className="mx-auto flex max-w-6xl flex-col gap-3 border-t border-black/10 px-4 py-4 text-xs uppercase tracking-[0.3em] text-black sm:px-6">
+            <Link
+              href="/reservations"
+              className="inline-flex items-center justify-center rounded-full border border-black px-4 py-2 font-semibold transition hover:bg-black hover:text-white"
+              onClick={handleCloseMenu}
+            >
+              Sur rendez-vous
+            </Link>
             {user ? (
-              <>
+              <div className="flex flex-col gap-3 text-black/80">
                 {isAdmin && (
-                  <Link href="/admin" className="hover:text-gray-300 bg-red-600 px-3 py-1 rounded">
-                    Admin
+                  <Link
+                    href="/admin"
+                    className="inline-flex items-center justify-center rounded-full border border-black px-4 py-2 font-semibold transition hover:bg-black hover:text-white"
+                    onClick={handleCloseMenu}
+                  >
+                    Espace admin
                   </Link>
                 )}
-                <span className="text-sm">Bonjour, {user.name}</span>
+                <span className="text-black/60">Bonjour, {user.name}</span>
                 <button
-                  onClick={logout}
-                  className="bg-red-500 hover:bg-red-600 px-4 py-2 rounded"
+                  type="button"
+                  onClick={() => {
+                    handleCloseMenu();
+                    logout();
+                  }}
+                  className="inline-flex items-center justify-center rounded-full bg-black px-4 py-2 font-semibold text-white transition hover:bg-black/80"
                 >
                   Déconnexion
                 </button>
-              </>
+              </div>
             ) : (
-              <>
-                <Link href="/login" className="hover:text-gray-300">
+              <div className="flex flex-col gap-3 text-black/80">
+                <Link
+                  href="/login"
+                  className="transition hover:text-black"
+                  onClick={handleCloseMenu}
+                >
                   Connexion
                 </Link>
                 <Link
                   href="/register"
-                  className="bg-blue-500 hover:bg-blue-600 px-4 py-2 rounded"
+                  className="inline-flex items-center justify-center rounded-full bg-black px-4 py-2 font-semibold text-white transition hover:bg-black/80"
+                  onClick={handleCloseMenu}
                 >
                   S&apos;inscrire
                 </Link>
-              </>
+              </div>
             )}
           </div>
         </div>
-      </div>
-    </nav>
+      )}
+    </header>
   );
 }
 


### PR DESCRIPTION
## Summary
- restyle the shared navbar to mirror the storefront header typography, palette, and spacing
- add a responsive menu experience with consistent button treatments for authentication and admin actions

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e165562b8883289e9eac75e9b10a3b