### PR TITLE
Normalize Firestore identifiers to strings

### DIFF
--- a/store-frontend/lib/AuthContext.tsx
+++ b/store-frontend/lib/AuthContext.tsx
@@ -4,7 +4,7 @@ import { createContext, useContext, useState, useEffect, ReactNode } from 'react
 import api from '@/lib/api';
 
 interface User {
-  id: number;
+  id: string;
   name: string;
   email: string;
   role: 'USER' | 'ADMIN';


### PR DESCRIPTION
## Summary
- update frontend interfaces so Firestore identifiers are consistently treated as strings
- relax admin page type guards to accept string IDs and propagate them directly to API calls
- normalize product and reservation payloads before use and submit reservation product IDs as strings

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e17715ee8883289ebf2acb25c5c2b3