### PR TITLE
Normalize API data and allow dynamic frontend origins

### DIFF
--- a/store-frontend/app/(with-navigation)/admin/page.tsx
+++ b/store-frontend/app/(with-navigation)/admin/page.tsx
@@ -5,105 +5,12 @@ import Image from 'next/image';
 import { useAuth } from '@/lib/AuthContext';
 import { useRouter } from 'next/navigation';
 import api, { getJson } from '@/lib/api';
-
-interface Product {
-  id: string;
-  name: string;
-  description: string;
-  price: number;
-  imageUrl: string;
-  category: string;
-  stock: number;
-  createdAt: string;
-  updatedAt?: string;
-}
-
-interface Reservation {
-  id: string;
-  quantity: number;
-  status: string;
-  createdAt: string;
-  user: {
-    id: string;
-    name: string;
-    email: string;
-  };
-  product: {
-    id: string;
-    name: string;
-    price: number;
-  };
-}
+import type { Product, Reservation } from '@/lib/types';
+import { parseProductList, parseReservationList } from '@/lib/normalizers';
 
 const truncateText = (text: string, maxLength = 120) => {
   if (!text) return '';
   return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
-};
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null;
-
-const ensureStringId = (record: Record<string, unknown>, key: string) => {
-  const rawId = record[key];
-
-  if (typeof rawId === 'string') {
-    return rawId;
-  }
-
-  if (typeof rawId === 'number') {
-    const normalized = rawId.toString();
-    record[key] = normalized;
-    return normalized;
-  }
-
-  return null;
-};
-
-const isProduct = (value: unknown): value is Product => {
-  if (!isRecord(value)) return false;
-
-  if (!ensureStringId(value, 'id')) {
-    return false;
-  }
-
-  return (
-    typeof value.name === 'string' &&
-    typeof value.price === 'number' &&
-    typeof value.stock === 'number' &&
-    typeof value.createdAt === 'string' &&
-    typeof value.imageUrl === 'string'
-  );
-};
-
-const isReservation = (value: unknown): value is Reservation => {
-  if (!isRecord(value)) return false;
-
-  if (!ensureStringId(value, 'id')) {
-    return false;
-  }
-
-  const { user, product } = value as {
-    user?: unknown;
-    product?: unknown;
-  };
-
-  if (!isRecord(user) || !isRecord(product)) {
-    return false;
-  }
-
-  if (!ensureStringId(user, 'id') || !ensureStringId(product, 'id')) {
-    return false;
-  }
-
-  return (
-    typeof value.quantity === 'number' &&
-    typeof value.status === 'string' &&
-    typeof value.createdAt === 'string' &&
-    typeof user.name === 'string' &&
-    typeof user.email === 'string' &&
-    typeof product.name === 'string' &&
-    typeof product.price === 'number'
-  );
 };
 
 export default function AdminPage() {
@@ -146,15 +53,21 @@ export default function AdminPage() {
         console.warn('Unexpected reservations response payload', rawReservations);
       }
 
-      const productsData = Array.isArray(rawProducts)
-        ? rawProducts.filter(isProduct)
-        : [];
-      const reservationsData = Array.isArray(rawReservations)
-        ? rawReservations.filter(isReservation)
-        : [];
+      const productsData = parseProductList(rawProducts);
+      const reservationsData = parseReservationList(rawReservations);
+
+      const toTimestamp = (value?: string) => {
+        if (!value) {
+          return 0;
+        }
+
+        const date = new Date(value);
+        const time = date.getTime();
+        return Number.isNaN(time) ? 0 : time;
+      };
 
       const sortedProducts = [...productsData].sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        (a, b) => toTimestamp(b.createdAt) - toTimestamp(a.createdAt),
       );
       setProducts(sortedProducts);
       setReservations(reservationsData);
@@ -230,7 +143,11 @@ export default function AdminPage() {
     setShowProductForm(false);
   };
 
-  const formatProductDate = (dateString: string) => {
+  const formatProductDate = (dateString?: string) => {
+    if (!dateString) {
+      return 'Date inconnue';
+    }
+
     const date = new Date(dateString);
     if (Number.isNaN(date.getTime())) {
       return 'Date inconnue';
@@ -242,7 +159,11 @@ export default function AdminPage() {
     });
   };
 
-  const isProductNew = (dateString: string) => {
+  const isProductNew = (dateString?: string) => {
+    if (!dateString) {
+      return false;
+    }
+
     const date = new Date(dateString);
     if (Number.isNaN(date.getTime())) {
       return false;
@@ -523,13 +444,17 @@ export default function AdminPage() {
               </tr>
             </thead>
             <tbody>
-              {reservations.map((reservation) => (
+              {reservations.map((reservation) => {
+                const customerName = reservation.user?.name ?? 'Client inconnu';
+                const customerEmail = reservation.user?.email ?? 'Email indisponible';
+
+                return (
                 <tr key={reservation.id} className="border-b hover:bg-gray-50">
                   <td className="px-4 py-3">{reservation.id}</td>
                   <td className="px-4 py-3">
-                    {reservation.user.name}
+                    {customerName}
                     <br />
-                    <span className="text-sm text-gray-500">{reservation.user.email}</span>
+                    <span className="text-sm text-gray-500">{customerEmail}</span>
                   </td>
                   <td className="px-4 py-3">{reservation.product.name}</td>
                   <td className="px-4 py-3">{reservation.quantity}</td>
@@ -563,7 +488,8 @@ export default function AdminPage() {
                     </select>
                   </td>
                 </tr>
-              ))}
+              );
+              })}
             </tbody>
           </table>
         </div>

--- a/store-frontend/app/articles/page.tsx
+++ b/store-frontend/app/articles/page.tsx
@@ -6,16 +6,8 @@ import Link from 'next/link';
 import { useAuth } from '@/lib/AuthContext';
 import { API_URL } from '@/lib/api';
 import { StorefrontLayout } from '@/components/StorefrontLayout';
-
-interface Product {
-  id: number;
-  name: string;
-  description: string;
-  price: number;
-  imageUrl: string;
-  category: string;
-  stock: number;
-}
+import type { Product } from '@/lib/types';
+import { parseProductList } from '@/lib/normalizers';
 
 export default function BoutiquePage() {
   const [products, setProducts] = useState<Product[]>([]);
@@ -41,7 +33,7 @@ export default function BoutiquePage() {
       }
       
       const data = await response.json();
-      setProducts(data);
+      setProducts(parseProductList(data));
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to load products';
       setError(errorMessage);
@@ -52,7 +44,16 @@ export default function BoutiquePage() {
   };
 
   // Get unique categories
-  const categories = ['all', ...Array.from(new Set(products.map(p => p.category).filter(Boolean)))];
+  const categories = [
+    'all',
+    ...Array.from(
+      new Set(
+        products
+          .map((product) => product.category)
+          .filter((category): category is string => typeof category === 'string' && category.trim().length > 0),
+      ),
+    ),
+  ];
 
   const filteredProducts = products.filter(product => {
     const matchesSearch = product.name.toLowerCase().includes(filter.toLowerCase()) ||

--- a/store-frontend/lib/normalizers.ts
+++ b/store-frontend/lib/normalizers.ts
@@ -1,0 +1,121 @@
+import type { Product, Reservation, ReservationUser } from './types';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const parseNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const parseOptionalString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+
+const parseString = (value: unknown): string | null => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return null;
+};
+
+export const parseProduct = (value: unknown): Product | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const id = value.id;
+  const name = parseString(value.name);
+  const price = parseNumber(value.price);
+  const imageUrl = parseString(value.imageUrl);
+  const stock = parseNumber(value.stock);
+
+  if ((typeof id !== 'string' && typeof id !== 'number') || !name || !imageUrl || price === null || stock === null) {
+    return null;
+  }
+
+  const description = parseOptionalString(value.description);
+  const category = parseOptionalString(value.category);
+  const createdAt = parseOptionalString(value.createdAt);
+  const updatedAt = parseOptionalString(value.updatedAt);
+
+  return {
+    id: String(id),
+    name,
+    description,
+    price,
+    imageUrl,
+    category,
+    stock: Math.max(0, Math.floor(stock)),
+    createdAt,
+    updatedAt,
+  } satisfies Product;
+};
+
+const parseReservationUser = (value: unknown): ReservationUser | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const id = value.id;
+  const name = parseString(value.name);
+  const email = parseString(value.email);
+
+  if ((typeof id !== 'string' && typeof id !== 'number') || !name || !email) {
+    return undefined;
+  }
+
+  return {
+    id: String(id),
+    name,
+    email,
+  } satisfies ReservationUser;
+};
+
+export const parseReservation = (value: unknown): Reservation | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const id = value.id;
+  const quantity = parseNumber(value.quantity);
+  const status = parseString(value.status);
+  const createdAt = parseString(value.createdAt);
+  const product = parseProduct(value.product);
+  const user = parseReservationUser(value.user);
+
+  if ((typeof id !== 'string' && typeof id !== 'number') || quantity === null || !status || !createdAt || !product) {
+    return null;
+  }
+
+  return {
+    id: String(id),
+    quantity: Math.max(0, Math.floor(quantity)),
+    status,
+    createdAt,
+    product,
+    ...(user ? { user } : {}),
+  } satisfies Reservation;
+};
+
+export const parseProductList = (value: unknown): Product[] =>
+  Array.isArray(value) ? value.map(parseProduct).filter((product): product is Product => product !== null) : [];
+
+export const parseReservationList = (value: unknown): Reservation[] =>
+  Array.isArray(value)
+    ? value.map(parseReservation).filter((reservation): reservation is Reservation => reservation !== null)
+    : [];

--- a/store-frontend/lib/types.ts
+++ b/store-frontend/lib/types.ts
@@ -1,0 +1,26 @@
+export interface Product {
+  id: string;
+  name: string;
+  description?: string;
+  price: number;
+  imageUrl: string;
+  category?: string;
+  stock: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ReservationUser {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export interface Reservation {
+  id: string;
+  quantity: number;
+  status: string;
+  createdAt: string;
+  product: Product;
+  user?: ReservationUser;
+}


### PR DESCRIPTION
## Summary
- add shared TypeScript types and normalizer helpers to sanitize API responses before rendering
- update admin, boutique, articles, and reservations pages to rely on the shared data layer and guard against missing fields
- broaden backend CORS configuration so Vercel and environment-configured frontends can talk to the API with credentials

## Testing
- pnpm --filter store-frontend lint
- CI=1 pnpm --filter store-frontend build
- pnpm --filter store-backend vercel-build
- node src/server.js

------
https://chatgpt.com/codex/tasks/task_b_68e1797f0c1883288061f396ff670ec3