### PR TITLE
Validate reservation quantities and stock updates

### DIFF
--- a/store-backend/src/controllers/reservationController.js
+++ b/store-backend/src/controllers/reservationController.js
@@ -7,6 +7,14 @@ const createReservation = async (req, res) => {
     const { productId, quantity } = req.body;
     const userId = req.user.id;
 
+    const parsedQuantity = Number(quantity);
+
+    if (!Number.isFinite(parsedQuantity) || !Number.isInteger(parsedQuantity) || parsedQuantity <= 0) {
+      return res.status(400).json({ error: 'Invalid quantity' });
+    }
+
+    const normalizedQuantity = parsedQuantity;
+
     // Check if product exists and has enough stock
     const product = await Product.findById(productId);
 
@@ -14,7 +22,7 @@ const createReservation = async (req, res) => {
       return res.status(404).json({ error: 'Product not found' });
     }
 
-    if (product.stock < quantity) {
+    if (product.stock < normalizedQuantity) {
       return res.status(400).json({ error: 'Insufficient stock' });
     }
 
@@ -22,12 +30,12 @@ const createReservation = async (req, res) => {
     const reservation = await Reservation.create({
       userId,
       productId,
-      quantity: parseInt(quantity),
+      quantity: normalizedQuantity,
       status: 'pending'
     });
 
     // Update product stock
-    await Product.updateStock(productId, -quantity);
+    await Product.updateStock(productId, -normalizedQuantity);
 
     // Get the complete reservation with product details
     const completeReservation = await Reservation.findById(reservation.id);

--- a/store-backend/src/models/Product.js
+++ b/store-backend/src/models/Product.js
@@ -87,21 +87,35 @@ class Product {
   }
 
   static async updateStock(id, stockChange) {
+    if (typeof stockChange !== 'number' || !Number.isFinite(stockChange) || !Number.isInteger(stockChange)) {
+      throw new Error('Invalid stock change value');
+    }
+
     try {
       const productRef = db.collection('products').doc(id);
       const product = await productRef.get();
-      
+
       if (!product.exists) {
         throw new Error('Product not found');
       }
-      
-      const currentStock = product.data().stock || 0;
+
+      const rawStock = product.data().stock;
+      const currentStock = rawStock === undefined ? 0 : rawStock;
+
+      if (typeof currentStock !== 'number' || !Number.isFinite(currentStock) || !Number.isInteger(currentStock)) {
+        throw new Error('Invalid product stock value');
+      }
+
       const newStock = currentStock + stockChange;
-      
+
       if (newStock < 0) {
         throw new Error('Insufficient stock');
       }
-      
+
+      if (!Number.isInteger(newStock)) {
+        throw new Error('Invalid resulting stock value');
+      }
+
       await productRef.update({
         stock: newStock,
         updatedAt: new Date()

--- a/store-backend/tests/productUpdateStock.test.js
+++ b/store-backend/tests/productUpdateStock.test.js
@@ -1,0 +1,84 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const configPath = path.resolve(__dirname, '../src/config/firebase.js');
+const productPath = path.resolve(__dirname, '../src/models/Product.js');
+
+function loadProductWithDb({ initialStock = 5 } = {}) {
+  delete require.cache[configPath];
+  delete require.cache[productPath];
+
+  const fakeProductRef = {
+    initialStock,
+    updates: [],
+    async get() {
+      return {
+        exists: true,
+        data: () => ({ stock: this.initialStock })
+      };
+    },
+    async update(data) {
+      this.updates.push(data);
+      this.initialStock = data.stock;
+    }
+  };
+
+  const fakeDb = {
+    collection(name) {
+      assert.equal(name, 'products');
+      return {
+        doc(id) {
+          fakeProductRef.id = id;
+          return fakeProductRef;
+        }
+      };
+    }
+  };
+
+  require.cache[configPath] = {
+    id: configPath,
+    filename: configPath,
+    loaded: true,
+    exports: { db: fakeDb, auth: {}, admin: {} }
+  };
+
+  const Product = require(productPath);
+
+  Product.findById = async id => ({ id, stock: fakeProductRef.initialStock });
+
+  return { Product, fakeProductRef };
+}
+
+function cleanupProductModules() {
+  delete require.cache[configPath];
+  delete require.cache[productPath];
+}
+
+test('updateStock rejects non-finite or non-integer stock changes', async (t) => {
+  const { Product } = loadProductWithDb();
+  t.after(cleanupProductModules);
+
+  await assert.rejects(Product.updateStock('p1', NaN), /Invalid stock change value/);
+  await assert.rejects(Product.updateStock('p1', Infinity), /Invalid stock change value/);
+  await assert.rejects(Product.updateStock('p1', 1.5), /Invalid stock change value/);
+});
+
+test('updateStock rejects non-integer stored stock levels', async (t) => {
+  const { Product } = loadProductWithDb({ initialStock: 5.5 });
+  t.after(cleanupProductModules);
+
+  await assert.rejects(Product.updateStock('p1', 1), /Invalid product stock value/);
+});
+
+test('updateStock applies integer deltas and preserves integer stock', async (t) => {
+  const { Product, fakeProductRef } = loadProductWithDb({ initialStock: 3 });
+  t.after(cleanupProductModules);
+
+  const result = await Product.updateStock('p1', 2);
+
+  assert.equal(fakeProductRef.updates.length, 1);
+  assert.equal(fakeProductRef.updates[0].stock, 5);
+  assert.equal(fakeProductRef.updates[0].stock % 1, 0);
+  assert.deepEqual(result, { id: 'p1', stock: 5 });
+});

--- a/store-backend/tests/reservationController.test.js
+++ b/store-backend/tests/reservationController.test.js
@@ -1,0 +1,137 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const controllerPath = path.resolve(__dirname, '../src/controllers/reservationController.js');
+const productModulePath = path.resolve(__dirname, '../src/models/Product.js');
+const reservationModulePath = path.resolve(__dirname, '../src/models/Reservation.js');
+
+function createResponseRecorder() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function loadControllerWithStubs({ productOverrides = {}, reservationOverrides = {} } = {}) {
+  delete require.cache[controllerPath];
+  delete require.cache[productModulePath];
+  delete require.cache[reservationModulePath];
+
+  const productStub = {
+    findByIdCalls: 0,
+    updateStockCalls: 0,
+    async findById(id) {
+      this.findByIdCalls += 1;
+      return { id, stock: 10 };
+    },
+    async updateStock(id, delta) {
+      this.updateStockCalls += 1;
+      this.updateStockArgs = { id, delta };
+      return { id, stock: 10 + delta };
+    },
+    ...productOverrides
+  };
+
+  const reservationStub = {
+    createCalls: 0,
+    findByIdCalls: 0,
+    async create(data) {
+      this.createCalls += 1;
+      this.createArgs = data;
+      return { id: 'reservation-1', ...data };
+    },
+    async findById(id) {
+      this.findByIdCalls += 1;
+      return { id };
+    },
+    ...reservationOverrides
+  };
+
+  require.cache[productModulePath] = {
+    id: productModulePath,
+    filename: productModulePath,
+    loaded: true,
+    exports: productStub
+  };
+
+  require.cache[reservationModulePath] = {
+    id: reservationModulePath,
+    filename: reservationModulePath,
+    loaded: true,
+    exports: reservationStub
+  };
+
+  const controller = require(controllerPath);
+
+  return { controller, productStub, reservationStub };
+}
+
+function cleanupModuleCache() {
+  delete require.cache[controllerPath];
+  delete require.cache[productModulePath];
+  delete require.cache[reservationModulePath];
+}
+
+test('createReservation rejects non-positive or non-numeric quantities', async (t) => {
+  const { controller, productStub, reservationStub } = loadControllerWithStubs();
+  t.after(cleanupModuleCache);
+
+  const invalidQuantities = [0, -1, 'abc', null, undefined];
+
+  for (const quantity of invalidQuantities) {
+    const req = {
+      body: { productId: 'product-1', quantity },
+      user: { id: 'user-1' }
+    };
+    const res = createResponseRecorder();
+
+    await controller.createReservation(req, res);
+
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.body, { error: 'Invalid quantity' });
+  }
+
+  assert.equal(productStub.findByIdCalls, 0);
+  assert.equal(productStub.updateStockCalls, 0);
+  assert.equal(reservationStub.createCalls, 0);
+});
+
+test('createReservation uses validated quantity for reservation and stock update', async (t) => {
+  const { controller, productStub, reservationStub } = loadControllerWithStubs({
+    async findById(id) {
+      this.findByIdCalls += 1;
+      return { id, stock: 5 };
+    }
+  }, {
+    async findById(id) {
+      this.findByIdCalls += 1;
+      return { id, product: { id: 'product-1' } };
+    }
+  });
+  t.after(cleanupModuleCache);
+
+  const req = {
+    body: { productId: 'product-1', quantity: '2' },
+    user: { id: 'user-1' }
+  };
+  const res = createResponseRecorder();
+
+  await controller.createReservation(req, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(productStub.findByIdCalls, 1);
+  assert.equal(reservationStub.createCalls, 1);
+  assert.equal(productStub.updateStockCalls, 1);
+  assert.equal(reservationStub.findByIdCalls, 1);
+  assert.equal(reservationStub.createArgs.quantity, 2);
+  assert.deepEqual(productStub.updateStockArgs, { id: 'product-1', delta: -2 });
+});


### PR DESCRIPTION
## Summary
- validate reservation quantities before fetching products and reuse the parsed integer for reservations and stock updates
- enforce integer-only stock updates and reject invalid stored stock values
- add node:test suites that cover reservation quantity validation and Product.updateStock guards

## Testing
- node --test store-backend/tests

------
https://chatgpt.com/codex/tasks/task_b_68e18e1bed8483288ca0a540de624a4d