### PR TITLE
Align campaign messaging and timestamps with October 2025

### DIFF
--- a/store-backend/README.md
+++ b/store-backend/README.md
@@ -60,6 +60,7 @@ store-backend/
 | `FIREBASE_SERVICE_ACCOUNT_KEY` | JSON string of service-account credentials | ✅ (Vercel) / ➖ (local default credentials) | `{ "type": "service_account", ... }` |
 | `FIREBASE_DATABASE_URL` | Firebase database URL used during Admin init | ✅ when using `FIREBASE_SERVICE_ACCOUNT_KEY` | `https://<project-id>.firebaseio.com` |
 | `GOOGLE_APPLICATION_CREDENTIALS` | File path to service-account JSON (local only) | ➖ | `/path/to/serviceAccount.json` |
+| `CAMPAIGN_LAUNCH_DATE` | ISO date used for campaign-aligned timestamps (defaults to `2025-10-01T09:00:00.000Z`) | ➖ | `2025-10-15T08:00:00.000Z` |
 
 > **Tip:** When copying the JSON into `FIREBASE_SERVICE_ACCOUNT_KEY`, escape double quotes or use single quotes in your `.env` file.
 

--- a/store-backend/prisma/schema.prisma
+++ b/store-backend/prisma/schema.prisma
@@ -35,8 +35,8 @@ model Product {
   category     String
   stock        Int
   reservations Reservation[]
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt
+  createdAt    DateTime      @default(dbgenerated("'2025-10-01T09:00:00.000Z'::timestamp"))
+  updatedAt    DateTime      @default(dbgenerated("'2025-10-01T09:00:00.000Z'::timestamp")) @updatedAt
 }
 
 model Reservation {

--- a/store-backend/src/config/launchDate.js
+++ b/store-backend/src/config/launchDate.js
@@ -1,0 +1,34 @@
+const DEFAULT_LAUNCH_DATE_ISO = '2025-10-01T09:00:00.000Z';
+
+const parseDate = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const getConfiguredLaunchDate = () => {
+  const configured = parseDate(process.env.CAMPAIGN_LAUNCH_DATE);
+  return configured || new Date(DEFAULT_LAUNCH_DATE_ISO);
+};
+
+const resolveTimestamp = (provided, { fallbackToCurrent = false } = {}) => {
+  const parsedProvided = parseDate(provided);
+  if (parsedProvided) {
+    return parsedProvided;
+  }
+
+  if (!fallbackToCurrent) {
+    return getConfiguredLaunchDate();
+  }
+
+  return new Date();
+};
+
+module.exports = {
+  DEFAULT_LAUNCH_DATE_ISO,
+  getConfiguredLaunchDate,
+  resolveTimestamp,
+};

--- a/store-frontend/app/page.tsx
+++ b/store-frontend/app/page.tsx
@@ -89,14 +89,15 @@ export default function Home() {
         <section className="grid gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
           <div className="space-y-8">
             <span className="inline-flex items-center rounded-full bg-black px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-white">
-              Nouvelle Collection 2024
+              Campagne Octobre 2025
             </span>
             <h1 className="text-3xl font-semibold tracking-[0.15em] sm:text-4xl lg:text-5xl">
-              Intemporel & Lumineux
+              Intemporel & Lumineux pour Octobre 2025
             </h1>
             <p className="max-w-xl text-sm leading-relaxed text-black/70 sm:text-base">
-              Des silhouettes sobres, sculptées dans des matières nobles, pensées pour souligner chaque instant de votre journée.
-              Notre équipe sélectionne des pièces raffinées qui dialoguent avec la lumière et la texture.
+              Une sélection capsule imaginée pour la campagne d’octobre 2025 : des silhouettes sobres, sculptées dans des matières
+              nobles, pensées pour illuminer vos moments de lancement. Notre équipe sélectionne des pièces raffinées qui dialoguent
+              avec la lumière et la texture.
             </p>
             <div className="flex flex-wrap gap-4 text-[0.65rem] uppercase tracking-[0.25em]">
               <Link

--- a/store-frontend/lib/mockData.ts
+++ b/store-frontend/lib/mockData.ts
@@ -1,7 +1,13 @@
 import type { Product, Reservation } from './types';
 
-const now = new Date();
-const dayInMs = 24 * 60 * 60 * 1000;
+const CAMPAIGN_BASE_ISO = '2025-10-01T09:00:00.000Z';
+
+const isoFromCampaign = (daysOffset: number, hoursOffset = 0) => {
+  const base = new Date(CAMPAIGN_BASE_ISO);
+  base.setUTCDate(base.getUTCDate() + daysOffset);
+  base.setUTCHours(base.getUTCHours() + hoursOffset);
+  return base.toISOString();
+};
 
 export const mockProducts: Product[] = [
   {
@@ -14,8 +20,8 @@ export const mockProducts: Product[] = [
       'https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=600&q=80',
     category: 'Bracelets',
     stock: 5,
-    createdAt: new Date(now.getTime() - dayInMs).toISOString(),
-    updatedAt: new Date(now.getTime() - dayInMs / 2).toISOString(),
+    createdAt: isoFromCampaign(2, 3),
+    updatedAt: isoFromCampaign(3, 1),
   },
   {
     id: 'mock-prod-2',
@@ -26,8 +32,8 @@ export const mockProducts: Product[] = [
       'https://images.unsplash.com/photo-1522312346375-d1a52e2b99b2?auto=format&fit=crop&w=600&q=80',
     category: 'Colliers',
     stock: 2,
-    createdAt: new Date(now.getTime() - 3 * dayInMs).toISOString(),
-    updatedAt: new Date(now.getTime() - 2 * dayInMs).toISOString(),
+    createdAt: isoFromCampaign(5, 6),
+    updatedAt: isoFromCampaign(6, 2),
   },
   {
     id: 'mock-prod-3',
@@ -38,8 +44,8 @@ export const mockProducts: Product[] = [
       'https://images.unsplash.com/photo-1520962918287-7448c2878f65?auto=format&fit=crop&w=600&q=80',
     category: 'Boucles',
     stock: 0,
-    createdAt: new Date(now.getTime() - 7 * dayInMs).toISOString(),
-    updatedAt: new Date(now.getTime() - 6 * dayInMs).toISOString(),
+    createdAt: isoFromCampaign(8, 9),
+    updatedAt: isoFromCampaign(9, 4),
   },
 ];
 
@@ -48,7 +54,7 @@ export const mockReservations: Reservation[] = [
     id: 'mock-res-1',
     quantity: 1,
     status: 'pending',
-    createdAt: new Date(now.getTime() - 2 * dayInMs).toISOString(),
+    createdAt: isoFromCampaign(4, 5),
     product: mockProducts[0],
     user: {
       id: 'mock-user-1',
@@ -60,7 +66,7 @@ export const mockReservations: Reservation[] = [
     id: 'mock-res-2',
     quantity: 2,
     status: 'confirmed',
-    createdAt: new Date(now.getTime() - 5 * dayInMs).toISOString(),
+    createdAt: isoFromCampaign(7, 8),
     product: mockProducts[1],
     user: {
       id: 'mock-user-2',


### PR DESCRIPTION
## Summary
- update the homepage hero badge and copy to reference the October 2025 campaign
- replace mock product and reservation timestamps with fixed October 2025 ISO values
- add a configurable campaign launch date for backend timestamps, align Prisma defaults, and document the new environment variable

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e19f2a21248328a98ef0784944e52a