### PR TITLE
Add highlighted products carousel to home hero

### DIFF
--- a/store-frontend/app/page.tsx
+++ b/store-frontend/app/page.tsx
@@ -1,8 +1,9 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { CuratedCollectionsSection, curatedCollections } from '@/components/CuratedCollections';
+import { CuratedCollectionsSection } from '@/components/CuratedCollections';
 import { HomeHeader, type HomeNavLink } from '@/components/HomeHeader';
 import { SiteFooter } from '@/components/SiteFooter';
+import { HotProductsCarousel } from '@/components/HotProductsCarousel';
 
 const navLinks: HomeNavLink[] = [
   { href: '/', label: 'Accueil' },
@@ -86,74 +87,7 @@ export default function Home() {
       <HomeHeader links={navLinks} />
 
       <main className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 pb-24 pt-20 sm:gap-20 sm:px-6 lg:gap-24 lg:px-8">
-        <section className="grid gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
-          <div className="space-y-8">
-            <span className="inline-flex items-center rounded-full bg-black px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-white">
-              Nouvelle Collection 2024
-            </span>
-            <h1 className="text-3xl font-semibold tracking-[0.15em] sm:text-4xl lg:text-5xl">
-              Intemporel & Lumineux
-            </h1>
-            <p className="max-w-xl text-sm leading-relaxed text-black/70 sm:text-base">
-              Des silhouettes sobres, sculptées dans des matières nobles, pensées pour souligner chaque instant de votre journée.
-              Notre équipe sélectionne des pièces raffinées qui dialoguent avec la lumière et la texture.
-            </p>
-            <div className="flex flex-wrap gap-4 text-[0.65rem] uppercase tracking-[0.25em]">
-              <Link
-                href="/boutique"
-                className="inline-flex items-center justify-center rounded-full bg-black px-8 py-3 font-semibold text-white transition hover:bg-black/80"
-              >
-                Découvrir la boutique
-              </Link>
-              <Link
-                href="#collections"
-                className="inline-flex items-center justify-center rounded-full border border-black px-8 py-3 font-semibold transition hover:bg-black hover:text-white"
-              >
-                Explorer les collections
-              </Link>
-            </div>
-            <div className="grid gap-4 sm:grid-cols-3">
-              <div className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm">
-                <p className="text-[0.65rem] uppercase tracking-[0.25em] text-black/60">Pièces sur mesure</p>
-                <p className="mt-3 text-xl font-semibold">48h</p>
-                <p className="mt-1 text-xs text-black/60">Délai de conception</p>
-              </div>
-              <div className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm">
-                <p className="text-[0.65rem] uppercase tracking-[0.25em] text-black/60">Ateliers privés</p>
-                <p className="mt-3 text-xl font-semibold">2 villes</p>
-                <p className="mt-1 text-xs text-black/60">Casablanca & Rabat</p>
-              </div>
-              <div className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm">
-                <p className="text-[0.65rem] uppercase tracking-[0.25em] text-black/60">Clients fidèles</p>
-                <p className="mt-3 text-xl font-semibold">8k+</p>
-                <p className="mt-1 text-xs text-black/60">Depuis 2012</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-6">
-            <div className="relative overflow-hidden rounded-[32px] border border-black/10 bg-white p-4 shadow-lg shadow-black/5">
-              <div className="relative h-72 w-full overflow-hidden rounded-[24px] sm:h-[22rem]">
-                <Image
-                  src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=1200&q=80"
-                  alt="Montre et accessoires Belhos"
-                  fill
-                  sizes="(max-width: 768px) 100vw, 50vw"
-                  className="object-cover"
-                  priority
-                />
-              </div>
-            </div>
-            <div className="grid gap-4 sm:grid-cols-2">
-              {curatedCollections.slice(0, 2).map((collection) => (
-                <div key={collection.title} className="rounded-2xl border border-black/10 bg-white p-5 text-sm shadow-sm">
-                  <p className="text-[0.65rem] uppercase tracking-[0.25em] text-black/60">{collection.title}</p>
-                  <p className="mt-2 text-xs uppercase tracking-[0.25em] text-black/60">{collection.priceRange}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
+        <HotProductsCarousel />
 
         <div id="collections">
           <CuratedCollectionsSection />

--- a/store-frontend/components/HotProductsCarousel.tsx
+++ b/store-frontend/components/HotProductsCarousel.tsx
@@ -1,0 +1,338 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useDataSource } from '@/lib/DataSourceContext';
+import { parseProductList } from '@/lib/normalizers';
+import { mockHighlightedProducts } from '@/lib/mockData';
+import type { Product } from '@/lib/types';
+import { curatedCollections } from '@/components/CuratedCollections';
+
+const AUTOPLAY_INTERVAL = 6500;
+
+const madFormatter = new Intl.NumberFormat('fr-MA', {
+  style: 'currency',
+  currency: 'MAD',
+  maximumFractionDigits: 0,
+});
+
+const formatPrice = (value: number) => madFormatter.format(value);
+
+const badgeStyles: Record<string, string> = {
+  hot: 'bg-amber-500 text-white',
+  new: 'bg-black text-white',
+  discount: 'bg-red-500 text-white',
+  default: 'bg-white text-black border border-black/10',
+};
+
+const getDiscountPercentage = (price: number, originalPrice?: number) => {
+  if (!originalPrice || originalPrice <= price) {
+    return null;
+  }
+
+  return Math.round(100 - (price / originalPrice) * 100);
+};
+
+export function HotProductsCarousel() {
+  const { mode, isReady } = useDataSource();
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const fetchHighlightedProducts = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      if (mode === 'mock') {
+        setProducts(parseProductList(mockHighlightedProducts));
+        return;
+      }
+
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api';
+      const requestUrl = `${apiUrl}/products?highlighted=true`;
+      const response = await fetch(requestUrl);
+
+      if (!response.ok) {
+        throw new Error(`Impossible de charger les produits mis en avant (${response.status})`);
+      }
+
+      const data = await response.json();
+      setProducts(parseProductList(data));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Impossible de charger les produits mis en avant';
+      setError(message);
+      console.error('[HotProductsCarousel] Failed to load highlighted products', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [mode]);
+
+  useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+
+    void fetchHighlightedProducts();
+  }, [fetchHighlightedProducts, isReady]);
+
+  const highlightedProducts = useMemo(() => {
+    if (products.length === 0) {
+      return [] as Product[];
+    }
+
+    const flagged = products.filter((product) => product.highlighted);
+    return flagged.length > 0 ? flagged : products;
+  }, [products]);
+
+  useEffect(() => {
+    if (currentIndex >= highlightedProducts.length) {
+      setCurrentIndex(0);
+    }
+  }, [currentIndex, highlightedProducts.length]);
+
+  useEffect(() => {
+    if (highlightedProducts.length <= 1) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      setCurrentIndex((previous) => (previous + 1) % highlightedProducts.length);
+    }, AUTOPLAY_INTERVAL);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [highlightedProducts.length]);
+
+  useEffect(() => {
+    if (highlightedProducts.length > 0) {
+      setCurrentIndex(0);
+    }
+  }, [highlightedProducts.length]);
+
+  const handlePrevious = () => {
+    if (highlightedProducts.length === 0) {
+      return;
+    }
+
+    setCurrentIndex((previous) => (previous - 1 + highlightedProducts.length) % highlightedProducts.length);
+  };
+
+  const handleNext = () => {
+    if (highlightedProducts.length === 0) {
+      return;
+    }
+
+    setCurrentIndex((previous) => (previous + 1) % highlightedProducts.length);
+  };
+
+  if (loading) {
+    return (
+      <section className="grid gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
+        <div className="space-y-8">
+          <div className="h-8 w-48 rounded-full bg-black/10" />
+          <div className="h-12 w-3/4 rounded-full bg-black/10" />
+          <div className="space-y-3">
+            <div className="h-4 w-full rounded-full bg-black/10" />
+            <div className="h-4 w-5/6 rounded-full bg-black/10" />
+          </div>
+          <div className="flex flex-wrap gap-4">
+            <div className="h-10 w-44 rounded-full bg-black/10" />
+            <div className="h-10 w-48 rounded-full bg-black/10" />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="h-28 rounded-2xl bg-black/5" />
+            <div className="h-28 rounded-2xl bg-black/5" />
+            <div className="h-28 rounded-2xl bg-black/5" />
+          </div>
+        </div>
+        <div className="space-y-6">
+          <div className="h-80 w-full rounded-[32px] border border-black/10 bg-black/5" />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="h-28 rounded-2xl bg-black/5" />
+            <div className="h-28 rounded-2xl bg-black/5" />
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="rounded-[32px] border border-black/10 bg-white p-12 text-center shadow-sm">
+        <p className="text-[0.65rem] uppercase tracking-[0.25em] text-black/60">Produit mis en avant</p>
+        <h2 className="mt-4 text-2xl font-semibold tracking-[0.15em]">Impossible de charger les produits</h2>
+        <p className="mt-3 text-sm text-black/60">{error}</p>
+        <button
+          onClick={fetchHighlightedProducts}
+          className="mt-6 inline-flex items-center justify-center rounded-full bg-black px-8 py-3 text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-white transition hover:bg-black/80"
+        >
+          Réessayer
+        </button>
+      </section>
+    );
+  }
+
+  if (highlightedProducts.length === 0) {
+    return null;
+  }
+
+  const product = highlightedProducts[currentIndex];
+  const hasDiscount = product.originalPrice !== undefined && product.originalPrice > product.price;
+  const discountPercentage = getDiscountPercentage(product.price, product.originalPrice ?? undefined);
+
+  const badgeEntries = [
+    ...(product.isHot ? [{ label: 'Coup de cœur', variant: 'hot' as const }] : []),
+    ...(product.isNew ? [{ label: 'Nouveauté', variant: 'new' as const }] : []),
+    ...(hasDiscount && discountPercentage !== null
+      ? [{ label: `-${discountPercentage}%`, variant: 'discount' as const }]
+      : []),
+    ...(product.badges?.map((label) => ({ label, variant: 'default' as const })) ?? []),
+  ];
+
+  const stockLabel = product.stock === 0 ? 'Rupture momentanée' : product.stock <= 5 ? `${product.stock} pièces` : `${product.stock}+ pièces`;
+  const lastUpdateLabel = product.updatedAt
+    ? new Intl.DateTimeFormat('fr-MA', { day: '2-digit', month: 'short' }).format(new Date(product.updatedAt))
+    : 'Cette semaine';
+
+  return (
+    <section className="grid gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
+      <div className="space-y-8">
+        <div className="flex flex-wrap items-center gap-3">
+          {badgeEntries.length === 0 ? (
+            <span className="inline-flex items-center rounded-full bg-black px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-white">
+              Sélection Belhos
+            </span>
+          ) : (
+            badgeEntries.map((badge) => (
+              <span
+                key={`${badge.variant}-${badge.label}`}
+                className={`inline-flex items-center rounded-full px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.25em] ${badgeStyles[badge.variant] ?? badgeStyles.default}`}
+              >
+                {badge.label}
+              </span>
+            ))
+          )}
+        </div>
+
+        <div className="space-y-4">
+          <h1 className="text-3xl font-semibold tracking-[0.15em] sm:text-4xl lg:text-5xl">{product.name}</h1>
+          {product.description && (
+            <p className="max-w-xl text-sm leading-relaxed text-black/70 sm:text-base">{product.description}</p>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-baseline gap-x-4 gap-y-2 text-[0.65rem] uppercase tracking-[0.25em]">
+          <span className="text-2xl font-semibold tracking-[0.15em] sm:text-3xl">{formatPrice(product.price)}</span>
+          {hasDiscount && product.originalPrice && (
+            <span className="text-sm font-medium text-black/50 line-through">{formatPrice(product.originalPrice)}</span>
+          )}
+          {product.category && <span className="rounded-full border border-black/10 px-3 py-1 text-black/60">{product.category}</span>}
+        </div>
+
+        <div className="flex flex-wrap gap-4 text-[0.65rem] uppercase tracking-[0.25em]">
+          <Link
+            href="/boutique"
+            className="inline-flex items-center justify-center rounded-full bg-black px-8 py-3 font-semibold text-white transition hover:bg-black/80"
+          >
+            Découvrir la boutique
+          </Link>
+          <Link
+            href="#collections"
+            className="inline-flex items-center justify-center rounded-full border border-black px-8 py-3 font-semibold transition hover:bg-black hover:text-white"
+          >
+            Explorer les collections
+          </Link>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <div className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm">
+            <p className="text-[0.65rem] uppercase tracking-[0.25em] text-black/60">Disponibilité</p>
+            <p className="mt-3 text-xl font-semibold">{stockLabel}</p>
+            <p className="mt-1 text-xs text-black/60">Stock surveillé en temps réel</p>
+          </div>
+          <div className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm">
+            <p className="text-[0.65rem] uppercase tracking-[0.25em] text-black/60">Actualisé</p>
+            <p className="mt-3 text-xl font-semibold">{lastUpdateLabel}</p>
+            <p className="mt-1 text-xs text-black/60">Dernière mise à jour</p>
+          </div>
+          <div className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm">
+            <p className="text-[0.65rem] uppercase tracking-[0.25em] text-black/60">Intérêt</p>
+            <p className="mt-3 text-xl font-semibold">{product.isHot ? 'Très élevé' : 'Équilibré'}</p>
+            <p className="mt-1 text-xs text-black/60">Suivi par notre équipe</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-6">
+        <div className="relative overflow-hidden rounded-[32px] border border-black/10 bg-white p-4 shadow-lg shadow-black/5">
+          <div className="relative h-72 w-full overflow-hidden rounded-[24px] sm:h-[22rem]">
+            <Image
+              src={product.imageUrl}
+              alt={product.name}
+              fill
+              sizes="(max-width: 768px) 100vw, 50vw"
+              className="object-cover transition duration-700"
+              priority
+            />
+            {hasDiscount && discountPercentage !== null && (
+              <div className="absolute left-4 top-4 rounded-full bg-black/80 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-white">
+                Promo -{discountPercentage}%
+              </div>
+            )}
+          </div>
+          <div className="absolute inset-x-0 bottom-6 flex items-center justify-between px-8">
+            <div className="flex items-center gap-2">
+              {highlightedProducts.map((item, index) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => setCurrentIndex(index)}
+                  className={`h-2.5 rounded-full transition ${
+                    index === currentIndex ? 'w-8 bg-black' : 'w-3 bg-black/30 hover:bg-black/60'
+                  }`}
+                >
+                  <span className="sr-only">{`Voir ${item.name}`}</span>
+                </button>
+              ))}
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handlePrevious}
+                className="flex h-10 w-10 items-center justify-center rounded-full border border-black/10 bg-white text-black transition hover:border-black/40"
+                aria-label="Voir le produit précédent"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 19l-7-7 7-7" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                onClick={handleNext}
+                className="flex h-10 w-10 items-center justify-center rounded-full border border-black/10 bg-white text-black transition hover:border-black/40"
+                aria-label="Voir le produit suivant"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5l7 7-7 7" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          {curatedCollections.slice(0, 2).map((collection) => (
+            <div key={collection.title} className="rounded-2xl border border-black/10 bg-white p-5 text-sm shadow-sm">
+              <p className="text-[0.65rem] uppercase tracking-[0.25em] text-black/60">{collection.title}</p>
+              <p className="mt-2 text-xs uppercase tracking-[0.25em] text-black/60">{collection.priceRange}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/store-frontend/lib/mockData.ts
+++ b/store-frontend/lib/mockData.ts
@@ -16,6 +16,10 @@ export const mockProducts: Product[] = [
     stock: 5,
     createdAt: new Date(now.getTime() - dayInMs).toISOString(),
     updatedAt: new Date(now.getTime() - dayInMs / 2).toISOString(),
+    highlighted: true,
+    isHot: true,
+    originalPrice: 159.99,
+    badges: ['Édition limitée'],
   },
   {
     id: 'mock-prod-2',
@@ -28,6 +32,7 @@ export const mockProducts: Product[] = [
     stock: 2,
     createdAt: new Date(now.getTime() - 3 * dayInMs).toISOString(),
     updatedAt: new Date(now.getTime() - 2 * dayInMs).toISOString(),
+    isNew: true,
   },
   {
     id: 'mock-prod-3',
@@ -40,6 +45,59 @@ export const mockProducts: Product[] = [
     stock: 0,
     createdAt: new Date(now.getTime() - 7 * dayInMs).toISOString(),
     updatedAt: new Date(now.getTime() - 6 * dayInMs).toISOString(),
+  },
+];
+
+export const mockHighlightedProducts: Product[] = [
+  {
+    id: 'mock-highlight-1',
+    name: 'Sac Cuir Opaline',
+    description:
+      'Cuir grainé ivoire, doublure en satin champagne et poignée torsadée confectionnée à la main.',
+    price: 980,
+    originalPrice: 1120,
+    imageUrl:
+      'https://images.unsplash.com/photo-1612810806695-30ba0b38fa13?auto=format&fit=crop&w=900&q=80',
+    category: 'Maroquinerie',
+    stock: 4,
+    createdAt: new Date(now.getTime() - dayInMs / 2).toISOString(),
+    updatedAt: new Date(now.getTime() - dayInMs / 4).toISOString(),
+    highlighted: true,
+    isHot: true,
+    badges: ['Atelier Casablanca'],
+  },
+  {
+    id: 'mock-highlight-2',
+    name: 'Montre Saphir Nuit',
+    description:
+      'Boîtier en acier bleu nuit, cadran laqué et bracelet en cuir nubuck avec surpiqûres main.',
+    price: 1480,
+    originalPrice: 1680,
+    imageUrl:
+      'https://images.unsplash.com/photo-1519408469771-2586093c3f14?auto=format&fit=crop&w=900&q=80',
+    category: 'Horlogerie',
+    stock: 3,
+    createdAt: new Date(now.getTime() - 2 * dayInMs).toISOString(),
+    updatedAt: new Date(now.getTime() - dayInMs).toISOString(),
+    highlighted: true,
+    isHot: true,
+    badges: ['Édition numérotée'],
+  },
+  {
+    id: 'mock-highlight-3',
+    name: 'Boucles Lumière Azur',
+    description:
+      'Argent rhodié et quartz bleuté, montés sur un serti griffes inspiré des motifs andalous.',
+    price: 620,
+    imageUrl:
+      'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=900&q=80',
+    category: 'Bijoux',
+    stock: 8,
+    createdAt: new Date(now.getTime() - dayInMs).toISOString(),
+    updatedAt: new Date(now.getTime() - dayInMs / 6).toISOString(),
+    highlighted: true,
+    isNew: true,
+    badges: ['Nouvelle collection'],
   },
 ];
 

--- a/store-frontend/lib/types.ts
+++ b/store-frontend/lib/types.ts
@@ -8,6 +8,11 @@ export interface Product {
   stock: number;
   createdAt?: string;
   updatedAt?: string;
+  highlighted?: boolean;
+  isHot?: boolean;
+  isNew?: boolean;
+  originalPrice?: number;
+  badges?: string[];
 }
 
 export interface ReservationUser {


### PR DESCRIPTION
## Summary
- add a client-side hot products carousel that auto-rotates highlighted products via the shared data source pipeline
- extend product normalization and mock data to expose hot/new/discount metadata for carousel badges
- replace the static home hero with the new responsive carousel component

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e19f20f7b08328bbe3a4d910eb1ebf