### PR TITLE
Add curated product categories and validation

### DIFF
--- a/store-backend/src/constants/productCategories.js
+++ b/store-backend/src/constants/productCategories.js
@@ -1,0 +1,21 @@
+const PRODUCT_CATEGORIES = [
+  { value: 'tech', label: 'Tech & Gadgets' },
+  { value: 'shoes', label: 'Chaussures' },
+  { value: 'clothes', label: 'Vêtements' },
+  { value: 'necklace', label: 'Colliers' },
+  { value: 'bracelet', label: 'Bracelets' },
+  { value: 'earrings', label: 'Boucles d\u2019oreilles' },
+  { value: 'watch', label: 'Montres' },
+  { value: 'bag', label: 'Sacs & Maroquinerie' },
+];
+
+const CATEGORY_VALUES = PRODUCT_CATEGORIES.map((category) => category.value);
+
+const isValidCategoryValue = (value) =>
+  typeof value === 'string' && CATEGORY_VALUES.includes(value);
+
+module.exports = {
+  PRODUCT_CATEGORIES,
+  CATEGORY_VALUES,
+  isValidCategoryValue,
+};

--- a/store-backend/src/controllers/productController.js
+++ b/store-backend/src/controllers/productController.js
@@ -1,4 +1,13 @@
 const Product = require('../models/Product');
+const { isValidCategoryValue } = require('../constants/productCategories');
+
+const normalizeCategoryInput = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim().toLowerCase();
+};
 
 // Get all products
 const getAllProducts = async (req, res) => {
@@ -53,12 +62,18 @@ const createProduct = async (req, res) => {
   try {
     const { name, description, price, imageUrl, category, stock } = req.body;
 
+    const normalizedCategory = normalizeCategoryInput(category);
+
+    if (normalizedCategory && !isValidCategoryValue(normalizedCategory)) {
+      return res.status(400).json({ error: 'Invalid category' });
+    }
+
     const product = await Product.create({
       name,
       description,
       price: price !== undefined ? Number.parseFloat(price) : undefined,
       imageUrl,
-      category,
+      category: normalizedCategory || undefined,
       stock: stock !== undefined ? Number.parseInt(stock, 10) : 0
     });
 
@@ -73,14 +88,24 @@ const createProduct = async (req, res) => {
 const updateProduct = async (req, res) => {
   try {
     const { id } = req.params;
-    const updateData = req.body;
-    
+    const updateData = { ...req.body };
+
     // Parse numeric fields
     if (updateData.price !== undefined) {
       updateData.price = Number.parseFloat(updateData.price);
     }
     if (updateData.stock !== undefined) {
       updateData.stock = Number.parseInt(updateData.stock, 10);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(updateData, 'category')) {
+      const normalizedCategory = normalizeCategoryInput(updateData.category);
+
+      if (normalizedCategory && !isValidCategoryValue(normalizedCategory)) {
+        return res.status(400).json({ error: 'Invalid category' });
+      }
+
+      updateData.category = normalizedCategory;
     }
 
     const product = await Product.update(id, updateData);

--- a/store-frontend/lib/categories.ts
+++ b/store-frontend/lib/categories.ts
@@ -1,0 +1,34 @@
+export const CATEGORY_OPTIONS = [
+  { value: 'tech', label: 'Tech & Gadgets' },
+  { value: 'shoes', label: 'Chaussures' },
+  { value: 'clothes', label: 'Vêtements' },
+  { value: 'necklace', label: 'Colliers' },
+  { value: 'bracelet', label: 'Bracelets' },
+  { value: 'earrings', label: 'Boucles d\u2019oreilles' },
+  { value: 'watch', label: 'Montres' },
+  { value: 'bag', label: 'Sacs & Maroquinerie' },
+] as const;
+
+export type CategoryValue = (typeof CATEGORY_OPTIONS)[number]['value'];
+
+export const CATEGORY_VALUE_SET = new Set(
+  CATEGORY_OPTIONS.map((option) => option.value),
+);
+
+export const CATEGORY_LABEL_MAP: Record<CategoryValue, string> =
+  CATEGORY_OPTIONS.reduce<Record<CategoryValue, string>>((acc, option) => {
+    acc[option.value] = option.label;
+    return acc;
+  }, Object.create(null));
+
+export const isAllowedCategoryValue = (
+  value: unknown,
+): value is CategoryValue =>
+  typeof value === 'string' && CATEGORY_VALUE_SET.has(value as CategoryValue);
+
+export const getCategoryLabel = (value?: string) => {
+  if (!value || !isAllowedCategoryValue(value)) {
+    return undefined;
+  }
+  return CATEGORY_LABEL_MAP[value];
+};

--- a/store-frontend/lib/mockData.ts
+++ b/store-frontend/lib/mockData.ts
@@ -12,7 +12,7 @@ export const mockProducts: Product[] = [
     price: 129.99,
     imageUrl:
       'https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=600&q=80',
-    category: 'Bracelets',
+    category: 'bracelet',
     stock: 5,
     createdAt: new Date(now.getTime() - dayInMs).toISOString(),
     updatedAt: new Date(now.getTime() - dayInMs / 2).toISOString(),
@@ -24,7 +24,7 @@ export const mockProducts: Product[] = [
     price: 189.5,
     imageUrl:
       'https://images.unsplash.com/photo-1522312346375-d1a52e2b99b2?auto=format&fit=crop&w=600&q=80',
-    category: 'Colliers',
+    category: 'necklace',
     stock: 2,
     createdAt: new Date(now.getTime() - 3 * dayInMs).toISOString(),
     updatedAt: new Date(now.getTime() - 2 * dayInMs).toISOString(),
@@ -36,10 +36,70 @@ export const mockProducts: Product[] = [
     price: 79.9,
     imageUrl:
       'https://images.unsplash.com/photo-1520962918287-7448c2878f65?auto=format&fit=crop&w=600&q=80',
-    category: 'Boucles',
+    category: 'earrings',
     stock: 0,
     createdAt: new Date(now.getTime() - 7 * dayInMs).toISOString(),
     updatedAt: new Date(now.getTime() - 6 * dayInMs).toISOString(),
+  },
+  {
+    id: 'mock-prod-4',
+    name: 'Sneakers Cuir Urbaines',
+    description: 'Des baskets en cuir pleine fleur avec semelle amortissante pour un confort premium.',
+    price: 159.0,
+    imageUrl:
+      'https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=600&q=80',
+    category: 'shoes',
+    stock: 8,
+    createdAt: new Date(now.getTime() - 2 * dayInMs).toISOString(),
+    updatedAt: new Date(now.getTime() - dayInMs).toISOString(),
+  },
+  {
+    id: 'mock-prod-5',
+    name: 'Sac cabas Cuir Cognac',
+    description: 'Un sac cabas spacieux en cuir grainé avec poignées renforcées.',
+    price: 249.5,
+    imageUrl:
+      'https://images.unsplash.com/photo-1612810806695-30ba0a094907?auto=format&fit=crop&w=600&q=80',
+    category: 'bag',
+    stock: 4,
+    createdAt: new Date(now.getTime() - 4 * dayInMs).toISOString(),
+    updatedAt: new Date(now.getTime() - 3 * dayInMs).toISOString(),
+  },
+  {
+    id: 'mock-prod-6',
+    name: 'Montre Acier Graphite',
+    description: 'Un garde-temps minimaliste avec bracelet en maille milanaise.',
+    price: 299.99,
+    imageUrl:
+      'https://images.unsplash.com/photo-1524594154907-23c985ca5c0c?auto=format&fit=crop&w=600&q=80',
+    category: 'watch',
+    stock: 3,
+    createdAt: new Date(now.getTime() - 6 * dayInMs).toISOString(),
+    updatedAt: new Date(now.getTime() - 4 * dayInMs).toISOString(),
+  },
+  {
+    id: 'mock-prod-7',
+    name: 'Chemisier Soie Écru',
+    description: 'Une coupe fluide en soie naturelle pour une allure sophistiquée.',
+    price: 139.99,
+    imageUrl:
+      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=600&q=80',
+    category: 'clothes',
+    stock: 6,
+    createdAt: new Date(now.getTime() - 8 * dayInMs).toISOString(),
+    updatedAt: new Date(now.getTime() - 7 * dayInMs).toISOString(),
+  },
+  {
+    id: 'mock-prod-8',
+    name: 'Écouteurs Sans Fil Signature',
+    description: 'Réduction de bruit active et autonomie de 24h pour accompagner vos journées.',
+    price: 219.0,
+    imageUrl:
+      'https://images.unsplash.com/photo-1512496015851-a90fb38ba796?auto=format&fit=crop&w=600&q=80',
+    category: 'tech',
+    stock: 10,
+    createdAt: new Date(now.getTime() - 5 * dayInMs).toISOString(),
+    updatedAt: new Date(now.getTime() - 4 * dayInMs).toISOString(),
   },
 ];
 

--- a/store-frontend/lib/normalizers.ts
+++ b/store-frontend/lib/normalizers.ts
@@ -1,4 +1,5 @@
 import type { Product, Reservation, ReservationUser } from './types';
+import { isAllowedCategoryValue } from './categories';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -49,7 +50,8 @@ export const parseProduct = (value: unknown): Product | null => {
   }
 
   const description = parseOptionalString(value.description);
-  const category = parseOptionalString(value.category);
+  const rawCategory = parseOptionalString(value.category);
+  const category = rawCategory && isAllowedCategoryValue(rawCategory) ? rawCategory : undefined;
   const createdAt = parseOptionalString(value.createdAt);
   const updatedAt = parseOptionalString(value.updatedAt);
 

--- a/store-frontend/lib/types.ts
+++ b/store-frontend/lib/types.ts
@@ -1,10 +1,12 @@
+import type { CategoryValue } from './categories';
+
 export interface Product {
   id: string;
   name: string;
   description?: string;
   price: number;
   imageUrl: string;
-  category?: string;
+  category?: CategoryValue;
   stock: number;
   createdAt?: string;
   updatedAt?: string;


### PR DESCRIPTION
## Summary
- add a shared list of curated product categories and update the admin form to use a select backed by it
- refresh mock catalogue data and storefront filters to display the curated labels consistently
- validate product category values on create/update endpoints to reject unsupported options

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e19f26a5848328aefb88a437bd958a