### PR TITLE
Define date constants for highlighted mock products

### DIFF
--- a/store-frontend/lib/mockData.ts
+++ b/store-frontend/lib/mockData.ts
@@ -49,6 +49,9 @@ export const mockProducts: Product[] = [
   },
 ];
 
+const now = new Date();
+const dayInMs = 24 * 60 * 60 * 1000;
+
 export const mockHighlightedProducts: Product[] = [
   {
     id: 'mock-highlight-1',


### PR DESCRIPTION
## Summary
- declare reusable `now` and `dayInMs` constants before the highlighted product mocks
- ensure highlighted product date fields rely on defined constants instead of undefined identifiers

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68e1a547886c832885290322458cc0e6