### PR TITLE
Use campaign year constant in site footer

### DIFF
--- a/store-frontend/components/SiteFooter.tsx
+++ b/store-frontend/components/SiteFooter.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
 
+import { CAMPAIGN_YEAR } from '@/lib/campaign';
+
 const footerLinks = [
   {
     title: 'Maison',
@@ -65,7 +67,7 @@ export function SiteFooter() {
 
         <div className="mt-12 flex flex-col gap-3 border-t border-black/10 pt-6 text-xs text-black/60 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
-            <p>&copy; {new Date().getFullYear()} Belhos Accessories. Tous droits réservés.</p>
+            <p>&copy; {CAMPAIGN_YEAR} Belhos Accessories. Tous droits réservés.</p>
             <p>
               Réalisé par{' '}
               <Link

--- a/store-frontend/lib/campaign.ts
+++ b/store-frontend/lib/campaign.ts
@@ -1,0 +1,3 @@
+export const CAMPAIGN_BASE_ISO = '2025-10-01T09:00:00.000Z';
+
+export const CAMPAIGN_YEAR = new Date(CAMPAIGN_BASE_ISO).getUTCFullYear().toString();

--- a/store-frontend/lib/mockData.ts
+++ b/store-frontend/lib/mockData.ts
@@ -1,6 +1,5 @@
 import type { Product, Reservation } from './types';
-
-const CAMPAIGN_BASE_ISO = '2025-10-01T09:00:00.000Z';
+import { CAMPAIGN_BASE_ISO } from './campaign';
 
 const isoFromCampaign = (daysOffset: number, hoursOffset = 0) => {
   const base = new Date(CAMPAIGN_BASE_ISO);


### PR DESCRIPTION
## Summary
- add a shared campaign constants module that exposes the base ISO date and derived campaign year
- update mock data and the footer component to consume the shared campaign year so the copyright text stays in sync with seeded data

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68e1b97fd680832892d7e056d732c62b