### PR TITLE
Ensure hero metadata is persisted when creating products

### DIFF
--- a/store-backend/src/models/Product.js
+++ b/store-backend/src/models/Product.js
@@ -1,6 +1,34 @@
 const { db } = require('../config/firebase');
 const { resolveTimestamp } = require('../config/launchDate');
 
+const sanitizeBadgeEntries = entries => {
+  if (!Array.isArray(entries)) {
+    return undefined;
+  }
+
+  const sanitized = entries.reduce((acc, entry) => {
+    if (typeof entry === 'string') {
+      const trimmed = entry.trim();
+      if (trimmed.length > 0) {
+        acc.push(trimmed);
+      }
+      return acc;
+    }
+
+    if (entry && typeof entry === 'object' && typeof entry.label === 'string') {
+      const trimmedLabel = entry.label.trim();
+      if (trimmedLabel.length > 0) {
+        acc.push(trimmedLabel);
+      }
+      return acc;
+    }
+
+    return acc;
+  }, []);
+
+  return sanitized.length > 0 ? sanitized : [];
+};
+
 const normalizeProductDocument = productDoc => {
   if (!productDoc || typeof productDoc.data !== 'function') {
     return null;
@@ -8,17 +36,28 @@ const normalizeProductDocument = productDoc => {
 
   const data = productDoc.data();
   const isHot = data.isHot === true;
+  const highlighted = data.highlighted === true;
+  const isNew = data.isNew === true;
   const badge =
     typeof data.badge === 'string' && data.badge.trim().length > 0 ? data.badge.trim() : null;
   const salePrice =
     typeof data.salePrice === 'number' && Number.isFinite(data.salePrice) ? data.salePrice : null;
+  const originalPrice =
+    typeof data.originalPrice === 'number' && Number.isFinite(data.originalPrice)
+      ? data.originalPrice
+      : null;
+  const badges = sanitizeBadgeEntries(data.badges);
 
   return {
     id: productDoc.id,
     ...data,
     isHot,
+    highlighted,
+    isNew,
     badge,
-    salePrice
+    salePrice,
+    originalPrice,
+    badges
   };
 };
 
@@ -32,13 +71,61 @@ class Product {
         price: rest.price,
         imageUrl: rest.imageUrl,
         category: rest.category || '',
-        stock: rest.stock || 0,
+        stock: typeof rest.stock === 'number' && Number.isFinite(rest.stock) ? rest.stock : 0,
         createdAt: resolveTimestamp(createdAt),
         updatedAt: resolveTimestamp(updatedAt || createdAt)
       };
 
+      if (rest.isHot !== undefined) {
+        productRecord.isHot = rest.isHot === true;
+      }
+
+      if (rest.highlighted !== undefined) {
+        productRecord.highlighted = rest.highlighted === true;
+      }
+
+      if (rest.isNew !== undefined) {
+        productRecord.isNew = rest.isNew === true;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(rest, 'badge')) {
+        if (rest.badge === null) {
+          productRecord.badge = null;
+        } else if (typeof rest.badge === 'string') {
+          const trimmedBadge = rest.badge.trim();
+          productRecord.badge = trimmedBadge.length > 0 ? trimmedBadge : null;
+        }
+      }
+
+      if (Object.prototype.hasOwnProperty.call(rest, 'salePrice')) {
+        if (rest.salePrice === null) {
+          productRecord.salePrice = null;
+        } else if (typeof rest.salePrice === 'number' && Number.isFinite(rest.salePrice)) {
+          productRecord.salePrice = rest.salePrice;
+        }
+      }
+
+      if (Object.prototype.hasOwnProperty.call(rest, 'originalPrice')) {
+        if (rest.originalPrice === null) {
+          productRecord.originalPrice = null;
+        } else if (typeof rest.originalPrice === 'number' && Number.isFinite(rest.originalPrice)) {
+          productRecord.originalPrice = rest.originalPrice;
+        }
+      }
+
+      if (Object.prototype.hasOwnProperty.call(rest, 'badges')) {
+        if (rest.badges === null) {
+          productRecord.badges = [];
+        } else if (Array.isArray(rest.badges)) {
+          const sanitizedBadges = sanitizeBadgeEntries(rest.badges);
+          if (sanitizedBadges !== undefined) {
+            productRecord.badges = sanitizedBadges;
+          }
+        }
+      }
+
       const productRef = await db.collection('products').add(productRecord);
-      
+
       const productDoc = await productRef.get();
       const normalized = normalizeProductDocument(productDoc);
       if (!normalized) {

--- a/store-backend/tests/productCreateHeroMetadata.test.js
+++ b/store-backend/tests/productCreateHeroMetadata.test.js
@@ -1,0 +1,177 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const firebaseConfigPath = path.resolve(__dirname, '../src/config/firebase.js');
+const productModelPath = path.resolve(__dirname, '../src/models/Product.js');
+const controllerPath = path.resolve(__dirname, '../src/controllers/productController.js');
+
+const clearModule = modulePath => {
+  delete require.cache[modulePath];
+};
+
+const loadProductForCreate = () => {
+  clearModule(firebaseConfigPath);
+  clearModule(productModelPath);
+
+  const storedRecords = [];
+
+  const fakeCollection = {
+    async add(data) {
+      storedRecords.push({ ...data });
+      return {
+        id: 'new-product',
+        async get() {
+          const latest = storedRecords[storedRecords.length - 1] || {};
+          return {
+            id: 'new-product',
+            data: () => ({ ...latest })
+          };
+        }
+      };
+    }
+  };
+
+  const fakeDb = {
+    collection(name) {
+      assert.equal(name, 'products');
+      return fakeCollection;
+    }
+  };
+
+  require.cache[firebaseConfigPath] = {
+    id: firebaseConfigPath,
+    filename: firebaseConfigPath,
+    loaded: true,
+    exports: { db: fakeDb, auth: {}, admin: {} }
+  };
+
+  const Product = require(productModelPath);
+
+  return { Product, storedRecords };
+};
+
+const restoreProductModules = () => {
+  clearModule(firebaseConfigPath);
+  clearModule(productModelPath);
+};
+
+test('Product.create persists hero metadata and normalizes the response', async t => {
+  const { Product, storedRecords } = loadProductForCreate();
+  t.after(restoreProductModules);
+
+  const product = await Product.create({
+    name: 'Hero Product',
+    description: 'Limited release',
+    price: 120,
+    imageUrl: 'https://example.com/hero.jpg',
+    category: 'bags',
+    stock: 7,
+    isHot: true,
+    highlighted: true,
+    isNew: false,
+    badge: '  Exclusive  ',
+    badges: [' Atelier ', { label: ' Numérotée ' }, '', null],
+    salePrice: 99,
+    originalPrice: 140
+  });
+
+  assert.equal(storedRecords.length, 1);
+  const stored = storedRecords[0];
+
+  assert.equal(stored.isHot, true);
+  assert.equal(stored.highlighted, true);
+  assert.equal(stored.isNew, false);
+  assert.equal(stored.badge, 'Exclusive');
+  assert.deepEqual(stored.badges, ['Atelier', 'Numérotée']);
+  assert.equal(stored.salePrice, 99);
+  assert.equal(stored.originalPrice, 140);
+  assert.equal(stored.stock, 7);
+  assert.ok(stored.createdAt instanceof Date);
+  assert.ok(stored.updatedAt instanceof Date);
+
+  assert.equal(product.isHot, true);
+  assert.equal(product.highlighted, true);
+  assert.equal(product.isNew, false);
+  assert.equal(product.badge, 'Exclusive');
+  assert.deepEqual(product.badges, ['Atelier', 'Numérotée']);
+  assert.equal(product.salePrice, 99);
+  assert.equal(product.originalPrice, 140);
+});
+
+const restoreControllerModules = () => {
+  clearModule(productModelPath);
+  clearModule(controllerPath);
+};
+
+test('createProduct controller forwards hero metadata to the model', async t => {
+  restoreControllerModules();
+
+  const received = {};
+  const fakeProductModule = {
+    async create(payload) {
+      Object.assign(received, payload);
+      return { id: 'created-product', ...payload };
+    }
+  };
+
+  require.cache[productModelPath] = {
+    id: productModelPath,
+    filename: productModelPath,
+    loaded: true,
+    exports: fakeProductModule
+  };
+
+  const { createProduct } = require(controllerPath);
+  t.after(restoreControllerModules);
+
+  const req = {
+    body: {
+      name: 'Controller Product',
+      description: 'Front display',
+      price: '150',
+      imageUrl: 'https://example.com/controller.jpg',
+      category: 'BAG',
+      stock: '3',
+      isHot: 'yes',
+      highlighted: 'false',
+      isNew: 'true',
+      badge: '  Coup de coeur ',
+      badges: '["Hero", " Hiver "]',
+      salePrice: '129.99',
+      originalPrice: '180'
+    }
+  };
+
+  const responsePayload = {};
+  const res = {
+    statusCode: 0,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      Object.assign(responsePayload, payload);
+    }
+  };
+
+  await createProduct(req, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(responsePayload.message, 'Product created');
+  assert.equal(received.name, 'Controller Product');
+  assert.equal(received.description, 'Front display');
+  assert.equal(received.price, 150);
+  assert.equal(received.imageUrl, 'https://example.com/controller.jpg');
+  assert.equal(received.category, 'bag');
+  assert.equal(received.stock, 3);
+  assert.equal(received.isHot, true);
+  assert.equal(received.highlighted, false);
+  assert.equal(received.isNew, true);
+  assert.equal(received.badge, 'Coup de coeur');
+  assert.deepEqual(received.badges, ['Hero', 'Hiver']);
+  assert.equal(received.salePrice, 129.99);
+  assert.equal(received.originalPrice, 180);
+});


### PR DESCRIPTION
## Summary
- parse hero slider request fields in the createProduct controller so hero metadata reaches the model
- persist hero slider booleans, pricing, and badges when creating products and expose them via normalization
- add tests for Product.create and the controller path to guard hero metadata handling

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_b_68e1ba337db88328941c8d00897ef5bd