### PR TITLE
Default data source to mock by default

### DIFF
--- a/store-frontend/lib/DataSourceContext.tsx
+++ b/store-frontend/lib/DataSourceContext.tsx
@@ -14,8 +14,30 @@ const STORAGE_KEY = 'belhos:data-source-mode';
 
 const DataSourceContext = createContext<DataSourceContextValue | undefined>(undefined);
 
+const DEFAULT_MODE: DataSourceMode = 'mock';
+
+const resolveHealthCheckUrl = (): string | null => {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api';
+
+  try {
+    const url = new URL(apiUrl);
+    const trimmedPath = url.pathname.replace(/\/$/, '');
+
+    if (trimmedPath.endsWith('/api')) {
+      url.pathname = `${trimmedPath.slice(0, -4)}/health`;
+    } else {
+      url.pathname = `${trimmedPath}/health`;
+    }
+
+    return url.toString();
+  } catch (error) {
+    console.warn('[DataSource] Unable to construct health check URL from NEXT_PUBLIC_API_URL', error);
+    return null;
+  }
+};
+
 export const DataSourceProvider = ({ children }: { children: React.ReactNode }) => {
-  const [mode, setModeState] = useState<DataSourceMode>('api');
+  const [mode, setModeState] = useState<DataSourceMode>(DEFAULT_MODE);
   const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
@@ -23,11 +45,75 @@ export const DataSourceProvider = ({ children }: { children: React.ReactNode }) 
       return;
     }
 
+    let isCancelled = false;
+
+    const commitMode = (nextMode: DataSourceMode) => {
+      if (isCancelled) {
+        return;
+      }
+
+      setModeState(nextMode);
+    };
+
+    const persistMode = (nextMode: DataSourceMode) => {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(STORAGE_KEY, nextMode);
+      }
+    };
+
+    const markReady = () => {
+      if (!isCancelled) {
+        setIsReady(true);
+      }
+    };
+
     const storedMode = window.localStorage.getItem(STORAGE_KEY);
-    if (storedMode === 'api' || storedMode === 'mock') {
-      setModeState(storedMode);
+    if (storedMode === 'mock') {
+      commitMode('mock');
+      markReady();
+      return () => {
+        isCancelled = true;
+      };
     }
-    setIsReady(true);
+
+    if (storedMode === 'api') {
+      markReady();
+
+      const healthCheckUrl = resolveHealthCheckUrl();
+      if (!healthCheckUrl) {
+        persistMode(DEFAULT_MODE);
+        commitMode(DEFAULT_MODE);
+        return () => {
+          isCancelled = true;
+        };
+      }
+
+      void fetch(healthCheckUrl)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`Health check failed with status ${response.status}`);
+          }
+
+          commitMode('api');
+        })
+        .catch((error) => {
+          console.warn('[DataSource] API mode unavailable during hydration, falling back to mock', error);
+          persistMode(DEFAULT_MODE);
+          commitMode(DEFAULT_MODE);
+        });
+
+      return () => {
+        isCancelled = true;
+      };
+    }
+
+    persistMode(DEFAULT_MODE);
+    commitMode(DEFAULT_MODE);
+    markReady();
+
+    return () => {
+      isCancelled = true;
+    };
   }, []);
 
   const setMode = useCallback((nextMode: DataSourceMode) => {


### PR DESCRIPTION
## Summary
- default the data source context to the mock catalogue when no prior preference is stored
- add a health check guard so stored API preferences fall back to mock mode if the backend is unreachable
- persist the chosen fallback in localStorage to keep highlighted products rendering during demos

## Testing
- pnpm --filter store-frontend lint

------
https://chatgpt.com/codex/tasks/task_b_68e1bbc532588328944058cd3a1f68b8